### PR TITLE
增加alignment字段控制视频排列

### DIFF
--- a/lib/src/chewie_player.dart
+++ b/lib/src/chewie_player.dart
@@ -169,6 +169,7 @@ class ChewieController extends ChangeNotifier {
   ChewieController({
     this.videoPlayerController,
     this.aspectRatio,
+    this.alignment,
     this.autoInitialize = false,
     this.autoPlay = false,
     this.startAt,
@@ -233,6 +234,10 @@ class ChewieController extends ChangeNotifier {
   ///
   /// Will fallback to fitting within the space allowed.
   final double aspectRatio;
+  
+  /// video alignment
+  /// default Alignment.center
+  final Alignment alignment;
 
   /// The colors to use for controls on iOS. By default, the iOS player uses
   /// colors sampled from the original iOS 11 designs.

--- a/lib/src/player_with_controls.dart
+++ b/lib/src/player_with_controls.dart
@@ -32,7 +32,8 @@ class PlayerWithControls extends StatelessWidget {
       child: Stack(
         children: <Widget>[
           chewieController.placeholder ?? Container(),
-          Center(
+          Container(
+            alignment: chewieController.alignment ?? Alignment.center,
             child: AspectRatio(
               aspectRatio: chewieController.aspectRatio ??
                   _calculateAspectRatio(context),


### PR DESCRIPTION
由于placeholder 能够居左，视频默认是center 此处改成Container 便于自定义