### PR TITLE
ChewieControllerProvider doesn't provide ChewieController's fields

### DIFF
--- a/lib/src/chewie_player.dart
+++ b/lib/src/chewie_player.dart
@@ -495,11 +495,14 @@ class ChewieController extends ChangeNotifier {
   /// Defines a custom RoutePageBuilder for the fullscreen
   final ChewieRoutePageBuilder? routePageBuilder;
 
-  static ChewieController of(BuildContext context) {
+  static ChewieController of<ChewieControllerProvider>(BuildContext context) {
+    if (null is ChewieControllerProvider) {
+      return context.dependOnInheritedWidgetOfExactType<ChewieController>()!;
+    }
     final chewieControllerProvider =
         context.dependOnInheritedWidgetOfExactType<ChewieControllerProvider>()!;
 
-    return chewieControllerProvider.controller;
+    return chewieControllerProvider.controller; 
   }
 
   bool _isFullScreen = false;


### PR DESCRIPTION
# Context
In my understanding is that`MaterialControls` uses `ChewieController.of` because wants to access the nearest `ChewieControllerProvider` on the tree, but the parent will be a `ChewieControllerProvider` instead of `ChewieController`.

`ChewieControllerProvider` isn't used on other parts (check it [here](https://github.com/fluttercommunity/chewie/search?q=ChewieControllerProvider). 

# Problem
The private field `_chewieController` in class `MaterialControls` ([line 130](https://github.com/fluttercommunity/chewie/blob/b131d6938a7fc863895e94f4c0e83e96679eabed/lib/src/material/material_controls.dart#L130)) uses `ChewieControllerProvider`, but this doesn't have the initialized fields of `ChewieController` (e.g. `allowMuting`, etc).

Why? Imaging you have this code:
```
_videoChewieController = ChewieController(
        videoPlayerController: _videoPlayerController,
        allowingMuting: false,
);
```
The muting button is shown on the controls, but it shouldn't show.

# Solution
I think few people use `ChewieControllerProvider`, for this reason I've changed the code in a way that the developer has to pass the type `ChewieControllerProvider` if he wants to use it.