### PR TITLE
[Android] Add a delay before displaying progress indicator

### DIFF
--- a/example/lib/app/app.dart
+++ b/example/lib/app/app.dart
@@ -42,7 +42,7 @@ class _ChewieDemoState extends State<ChewieDemo> {
   }
 
   List<String> srcs = [
-    "https://upload.wikimedia.org/wikipedia/commons/2/2c/Earth_rotation_during_Galileo_flyby_%28PIA00114%29_%28color-adjusted%29.webm",
+    "https://assets.mixkit.co/videos/preview/mixkit-spinning-around-the-earth-29351-large.mp4",
     "https://assets.mixkit.co/videos/preview/mixkit-daytime-city-traffic-aerial-view-56-large.mp4",
     "https://assets.mixkit.co/videos/preview/mixkit-a-girl-blowing-a-bubble-gum-at-an-amusement-park-1226-large.mp4"
   ];

--- a/example/lib/app/app.dart
+++ b/example/lib/app/app.dart
@@ -317,12 +317,7 @@ class _ChewieDemoState extends State<ChewieDemo> {
                   delay: _chewieController?.progressIndicatorDelayMs,
                   onSave: (delay) async {
                     if (delay != null) {
-                      if (delay == 0) {
-                        bufferDelay = null;
-                      } else {
-                        bufferDelay = delay;
-                      }
-
+                      bufferDelay = delay == 0 ? null : delay;
                       await initializePlayer();
                     }
                   },

--- a/example/lib/app/app.dart
+++ b/example/lib/app/app.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:chewie/chewie.dart';
 import 'package:chewie_example/app/theme.dart';
 import 'package:flutter/material.dart';
@@ -308,23 +310,24 @@ class _ChewieDemoState extends State<ChewieDemo> {
                 ),
               ],
             ),
-            ListTile(
-              title: const Text("Delay"),
-              subtitle: DelaySlider(
-                delay: _chewieController?.progressIndicatorDelayMS,
-                onSave: (delay) async {
-                  if (delay != null) {
-                    if (delay == 0) {
-                      bufferDelay = null;
-                    } else {
-                      bufferDelay = delay;
-                    }
+            if (Platform.isAndroid)
+              ListTile(
+                title: const Text("Delay"),
+                subtitle: DelaySlider(
+                  delay: _chewieController?.progressIndicatorDelayMS,
+                  onSave: (delay) async {
+                    if (delay != null) {
+                      if (delay == 0) {
+                        bufferDelay = null;
+                      } else {
+                        bufferDelay = delay;
+                      }
 
-                    await initializePlayer();
-                  }
-                },
-              ),
-            )
+                      await initializePlayer();
+                    }
+                  },
+                ),
+              )
           ],
         ),
       ),

--- a/example/lib/app/app.dart
+++ b/example/lib/app/app.dart
@@ -114,7 +114,8 @@ class _ChewieDemoState extends State<ChewieDemo> {
       videoPlayerController: _videoPlayerController1,
       autoPlay: true,
       looping: true,
-      progressIndicatorDelayMs: bufferDelay,
+      progressIndicatorDelay:
+          bufferDelay != null ? Duration(milliseconds: bufferDelay!) : null,
 
       additionalOptions: (context) {
         return <OptionItem>[
@@ -314,7 +315,8 @@ class _ChewieDemoState extends State<ChewieDemo> {
               ListTile(
                 title: const Text("Delay"),
                 subtitle: DelaySlider(
-                  delay: _chewieController?.progressIndicatorDelayMs,
+                  delay:
+                      _chewieController?.progressIndicatorDelay?.inMilliseconds,
                   onSave: (delay) async {
                     if (delay != null) {
                       bufferDelay = delay == 0 ? null : delay;

--- a/example/lib/app/app.dart
+++ b/example/lib/app/app.dart
@@ -23,6 +23,7 @@ class _ChewieDemoState extends State<ChewieDemo> {
   late VideoPlayerController _videoPlayerController1;
   late VideoPlayerController _videoPlayerController2;
   ChewieController? _chewieController;
+  int? bufferDelay;
 
   @override
   void initState() {
@@ -111,6 +112,7 @@ class _ChewieDemoState extends State<ChewieDemo> {
       videoPlayerController: _videoPlayerController1,
       autoPlay: true,
       looping: true,
+      progressIndicatorDelayMS: bufferDelay,
 
       additionalOptions: (context) {
         return <OptionItem>[
@@ -306,8 +308,85 @@ class _ChewieDemoState extends State<ChewieDemo> {
                 ),
               ],
             ),
+            ListTile(
+              title: const Text("Delay"),
+              subtitle: Column(
+                children: [
+                  DelaySlider(
+                    delay: _chewieController?.progressIndicatorDelayMS,
+                    onSave: (delay) async {
+                      if (delay != null) {
+                        if (delay == 0) {
+                          bufferDelay = null;
+                        } else {
+                          bufferDelay = delay;
+                        }
+
+                        await initializePlayer();
+                      }
+                    },
+                  ),
+                  Text(
+                    _chewieController?.progressIndicatorDelayMS != null
+                        ? "Progress indicator delay ${_chewieController!.progressIndicatorDelayMS.toString()} MS"
+                        : "Set me",
+                  ),
+                ],
+              ),
+            )
           ],
         ),
+      ),
+    );
+  }
+}
+
+class DelaySlider extends StatefulWidget {
+  const DelaySlider({Key? key, required this.delay, required this.onSave})
+      : super(key: key);
+
+  final int? delay;
+  final void Function(int?) onSave;
+  @override
+  State<DelaySlider> createState() => _DelaySliderState();
+}
+
+class _DelaySliderState extends State<DelaySlider> {
+  int? delay;
+  bool saved = false;
+
+  @override
+  void initState() {
+    super.initState();
+    delay = widget.delay;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    const int max = 1000;
+    return ListTile(
+      title: Text(
+        "Progress indicator delay ${delay != null ? "${delay.toString()} MS" : ""}",
+      ),
+      subtitle: Slider(
+        value: delay != null ? (delay! / max) : 0,
+        onChanged: (value) async {
+          delay = (value * max).toInt();
+          setState(() {
+            saved = false;
+          });
+        },
+      ),
+      trailing: IconButton(
+        icon: const Icon(Icons.save),
+        onPressed: saved
+            ? null
+            : () {
+                widget.onSave(delay);
+                setState(() {
+                  saved = true;
+                });
+              },
       ),
     );
   }

--- a/example/lib/app/app.dart
+++ b/example/lib/app/app.dart
@@ -114,7 +114,7 @@ class _ChewieDemoState extends State<ChewieDemo> {
       videoPlayerController: _videoPlayerController1,
       autoPlay: true,
       looping: true,
-      progressIndicatorDelayMS: bufferDelay,
+      progressIndicatorDelayMs: bufferDelay,
 
       additionalOptions: (context) {
         return <OptionItem>[
@@ -314,7 +314,7 @@ class _ChewieDemoState extends State<ChewieDemo> {
               ListTile(
                 title: const Text("Delay"),
                 subtitle: DelaySlider(
-                  delay: _chewieController?.progressIndicatorDelayMS,
+                  delay: _chewieController?.progressIndicatorDelayMs,
                   onSave: (delay) async {
                     if (delay != null) {
                       if (delay == 0) {

--- a/example/lib/app/app.dart
+++ b/example/lib/app/app.dart
@@ -310,28 +310,19 @@ class _ChewieDemoState extends State<ChewieDemo> {
             ),
             ListTile(
               title: const Text("Delay"),
-              subtitle: Column(
-                children: [
-                  DelaySlider(
-                    delay: _chewieController?.progressIndicatorDelayMS,
-                    onSave: (delay) async {
-                      if (delay != null) {
-                        if (delay == 0) {
-                          bufferDelay = null;
-                        } else {
-                          bufferDelay = delay;
-                        }
+              subtitle: DelaySlider(
+                delay: _chewieController?.progressIndicatorDelayMS,
+                onSave: (delay) async {
+                  if (delay != null) {
+                    if (delay == 0) {
+                      bufferDelay = null;
+                    } else {
+                      bufferDelay = delay;
+                    }
 
-                        await initializePlayer();
-                      }
-                    },
-                  ),
-                  Text(
-                    _chewieController?.progressIndicatorDelayMS != null
-                        ? "Progress indicator delay ${_chewieController!.progressIndicatorDelayMS.toString()} MS"
-                        : "Set me",
-                  ),
-                ],
+                    await initializePlayer();
+                  }
+                },
               ),
             )
           ],

--- a/example/lib/app/app.dart
+++ b/example/lib/app/app.dart
@@ -39,6 +39,7 @@ class _ChewieDemoState extends State<ChewieDemo> {
   }
 
   List<String> srcs = [
+    "https://upload.wikimedia.org/wikipedia/commons/2/2c/Earth_rotation_during_Galileo_flyby_%28PIA00114%29_%28color-adjusted%29.webm",
     "https://assets.mixkit.co/videos/preview/mixkit-daytime-city-traffic-aerial-view-56-large.mp4",
     "https://assets.mixkit.co/videos/preview/mixkit-a-girl-blowing-a-bubble-gum-at-an-amusement-park-1226-large.mp4"
   ];
@@ -155,7 +156,10 @@ class _ChewieDemoState extends State<ChewieDemo> {
 
   Future<void> toggleVideo() async {
     await _videoPlayerController1.pause();
-    currPlayIndex = currPlayIndex == 0 ? 1 : 0;
+    currPlayIndex += 1;
+    if (currPlayIndex >= srcs.length) {
+      currPlayIndex = 0;
+    }
     await initializePlayer();
   }
 

--- a/lib/src/chewie_player.dart
+++ b/lib/src/chewie_player.dart
@@ -519,7 +519,7 @@ class ChewieController extends ChangeNotifier {
   /// Defines a custom RoutePageBuilder for the fullscreen
   final ChewieRoutePageBuilder? routePageBuilder;
 
-  /// [Android] Defines a delay in milliseconds between entering buffering state and displaying the loading spinner. Set null (default) to disable it.
+  /// Defines a delay in milliseconds between entering buffering state and displaying the loading spinner. Set null (default) to disable it.
   final Duration? progressIndicatorDelay;
 
   static ChewieController of(BuildContext context) {

--- a/lib/src/chewie_player.dart
+++ b/lib/src/chewie_player.dart
@@ -281,7 +281,7 @@ class ChewieController extends ChangeNotifier {
     this.deviceOrientationsAfterFullScreen = DeviceOrientation.values,
     this.routePageBuilder,
     this.hideControlsTimer = defaultHideControlsTimer,
-    this.progressIndicatorDelayMS,
+    this.progressIndicatorDelayMs,
   }) : assert(
           playbackSpeeds.every((speed) => speed > 0),
           'The playbackSpeeds values must all be greater than 0',
@@ -325,7 +325,7 @@ class ChewieController extends ChangeNotifier {
     List<DeviceOrientation>? deviceOrientationsOnEnterFullScreen,
     List<SystemUiOverlay>? systemOverlaysAfterFullScreen,
     List<DeviceOrientation>? deviceOrientationsAfterFullScreen,
-    int? progressIndicatorDelayMS,
+    int? progressIndicatorDelayMs,
     Widget Function(
       BuildContext,
       Animation<double>,
@@ -379,8 +379,8 @@ class ChewieController extends ChangeNotifier {
           this.deviceOrientationsAfterFullScreen,
       routePageBuilder: routePageBuilder ?? this.routePageBuilder,
       hideControlsTimer: hideControlsTimer ?? this.hideControlsTimer,
-      progressIndicatorDelayMS:
-          progressIndicatorDelayMS ?? this.progressIndicatorDelayMS,
+      progressIndicatorDelayMs:
+          progressIndicatorDelayMs ?? this.progressIndicatorDelayMs,
     );
   }
 
@@ -518,7 +518,7 @@ class ChewieController extends ChangeNotifier {
   final ChewieRoutePageBuilder? routePageBuilder;
 
   /// [Android] Defines a delay in milliseconds between entering buffering state and displaying the loading spinner. Set null (default) to disable it.
-  final int? progressIndicatorDelayMS;
+  final int? progressIndicatorDelayMs;
 
   static ChewieController of(BuildContext context) {
     final chewieControllerProvider =

--- a/lib/src/chewie_player.dart
+++ b/lib/src/chewie_player.dart
@@ -282,7 +282,6 @@ class ChewieController extends ChangeNotifier {
     this.routePageBuilder,
     this.progressIndicatorDelay,
     this.hideControlsTimer = defaultHideControlsTimer,
-    this.progressIndicatorDelayMs,
   }) : assert(
           playbackSpeeds.every((speed) => speed > 0),
           'The playbackSpeeds values must all be greater than 0',
@@ -382,7 +381,6 @@ class ChewieController extends ChangeNotifier {
       hideControlsTimer: hideControlsTimer ?? this.hideControlsTimer,
       progressIndicatorDelay:
           progressIndicatorDelay ?? this.progressIndicatorDelay,
-      hideControlsTimer: hideControlsTimer ?? this.hideControlsTimer,
     );
   }
 

--- a/lib/src/chewie_player.dart
+++ b/lib/src/chewie_player.dart
@@ -281,6 +281,7 @@ class ChewieController extends ChangeNotifier {
     this.deviceOrientationsAfterFullScreen = DeviceOrientation.values,
     this.routePageBuilder,
     this.hideControlsTimer = defaultHideControlsTimer,
+    this.progressIndicatorDelayMS,
   }) : assert(
           playbackSpeeds.every((speed) => speed > 0),
           'The playbackSpeeds values must all be greater than 0',
@@ -324,6 +325,7 @@ class ChewieController extends ChangeNotifier {
     List<DeviceOrientation>? deviceOrientationsOnEnterFullScreen,
     List<SystemUiOverlay>? systemOverlaysAfterFullScreen,
     List<DeviceOrientation>? deviceOrientationsAfterFullScreen,
+    int? bufferingProgressIndicatorDisplayDelayMS,
     Widget Function(
       BuildContext,
       Animation<double>,
@@ -377,7 +379,8 @@ class ChewieController extends ChangeNotifier {
           this.deviceOrientationsAfterFullScreen,
       routePageBuilder: routePageBuilder ?? this.routePageBuilder,
       hideControlsTimer: hideControlsTimer ?? this.hideControlsTimer,
-    );
+      progressIndicatorDelayMS: bufferingProgressIndicatorDisplayDelayMS ??
+            this.progressIndicatorDelayMS);
   }
 
   static const defaultHideControlsTimer = Duration(seconds: 3);
@@ -512,6 +515,9 @@ class ChewieController extends ChangeNotifier {
 
   /// Defines a custom RoutePageBuilder for the fullscreen
   final ChewieRoutePageBuilder? routePageBuilder;
+
+  /// [Android] Defines a delay in milliseconds between entering buffering state and displaying the loading spinner. Set null (default) to disable it.
+  final int? progressIndicatorDelayMS;
 
   static ChewieController of(BuildContext context) {
     final chewieControllerProvider =

--- a/lib/src/chewie_player.dart
+++ b/lib/src/chewie_player.dart
@@ -325,7 +325,7 @@ class ChewieController extends ChangeNotifier {
     List<DeviceOrientation>? deviceOrientationsOnEnterFullScreen,
     List<SystemUiOverlay>? systemOverlaysAfterFullScreen,
     List<DeviceOrientation>? deviceOrientationsAfterFullScreen,
-    int? bufferingProgressIndicatorDisplayDelayMS,
+    int? progressIndicatorDelayMS,
     Widget Function(
       BuildContext,
       Animation<double>,
@@ -379,8 +379,9 @@ class ChewieController extends ChangeNotifier {
           this.deviceOrientationsAfterFullScreen,
       routePageBuilder: routePageBuilder ?? this.routePageBuilder,
       hideControlsTimer: hideControlsTimer ?? this.hideControlsTimer,
-      progressIndicatorDelayMS: bufferingProgressIndicatorDisplayDelayMS ??
-            this.progressIndicatorDelayMS);
+      progressIndicatorDelayMS:
+          progressIndicatorDelayMS ?? this.progressIndicatorDelayMS,
+    );
   }
 
   static const defaultHideControlsTimer = Duration(seconds: 3);

--- a/lib/src/chewie_player.dart
+++ b/lib/src/chewie_player.dart
@@ -280,6 +280,7 @@ class ChewieController extends ChangeNotifier {
     this.systemOverlaysAfterFullScreen = SystemUiOverlay.values,
     this.deviceOrientationsAfterFullScreen = DeviceOrientation.values,
     this.routePageBuilder,
+    this.progressIndicatorDelay,
     this.hideControlsTimer = defaultHideControlsTimer,
     this.progressIndicatorDelayMs,
   }) : assert(
@@ -325,7 +326,7 @@ class ChewieController extends ChangeNotifier {
     List<DeviceOrientation>? deviceOrientationsOnEnterFullScreen,
     List<SystemUiOverlay>? systemOverlaysAfterFullScreen,
     List<DeviceOrientation>? deviceOrientationsAfterFullScreen,
-    int? progressIndicatorDelayMs,
+    Duration? progressIndicatorDelay,
     Widget Function(
       BuildContext,
       Animation<double>,
@@ -379,8 +380,9 @@ class ChewieController extends ChangeNotifier {
           this.deviceOrientationsAfterFullScreen,
       routePageBuilder: routePageBuilder ?? this.routePageBuilder,
       hideControlsTimer: hideControlsTimer ?? this.hideControlsTimer,
-      progressIndicatorDelayMs:
-          progressIndicatorDelayMs ?? this.progressIndicatorDelayMs,
+      progressIndicatorDelay:
+          progressIndicatorDelay ?? this.progressIndicatorDelay,
+      hideControlsTimer: hideControlsTimer ?? this.hideControlsTimer,
     );
   }
 
@@ -518,7 +520,7 @@ class ChewieController extends ChangeNotifier {
   final ChewieRoutePageBuilder? routePageBuilder;
 
   /// [Android] Defines a delay in milliseconds between entering buffering state and displaying the loading spinner. Set null (default) to disable it.
-  final int? progressIndicatorDelayMs;
+  final Duration? progressIndicatorDelay;
 
   static ChewieController of(BuildContext context) {
     final chewieControllerProvider =

--- a/lib/src/cupertino/cupertino_controls.dart
+++ b/lib/src/cupertino/cupertino_controls.dart
@@ -47,6 +47,8 @@ class _CupertinoControlsState extends State<CupertinoControls>
   bool _dragging = false;
   Duration? _subtitlesPosition;
   bool _subtitleOn = false;
+  Timer? _bufferingDisplayTimer;
+  bool _displayBufferingIndicator = false;
 
   late VideoPlayerController controller;
 
@@ -91,7 +93,7 @@ class _CupertinoControlsState extends State<CupertinoControls>
           absorbing: notifier.hideStuff,
           child: Stack(
             children: [
-              if (_latestValue.isBuffering)
+              if (_displayBufferingIndicator)
                 const Center(
                   child: CircularProgressIndicator(),
                 )
@@ -769,8 +771,32 @@ class _CupertinoControlsState extends State<CupertinoControls>
     });
   }
 
+  void _bufferingTimerTimeout() {
+    _displayBufferingIndicator = true;
+    if (mounted) {
+      setState(() {});
+    }
+  }
+
   void _updateState() {
     if (!mounted) return;
+
+    // display the progress bar indicator only after the buffering delay if it has been set
+    if (chewieController.progressIndicatorDelay != null) {
+      if (controller.value.isBuffering) {
+        _bufferingDisplayTimer ??= Timer(
+          chewieController.progressIndicatorDelay!,
+          _bufferingTimerTimeout,
+        );
+      } else {
+        _bufferingDisplayTimer?.cancel();
+        _bufferingDisplayTimer = null;
+        _displayBufferingIndicator = false;
+      }
+    } else {
+      _displayBufferingIndicator = controller.value.isBuffering;
+    }
+
     setState(() {
       _latestValue = controller.value;
       _subtitlesPosition = controller.value.position;

--- a/lib/src/material/material_controls.dart
+++ b/lib/src/material/material_controls.dart
@@ -564,12 +564,10 @@ class _MaterialControlsState extends State<MaterialControls>
     if (!mounted) return;
 
     // display the progress bar indicator only after the buffering delay if it has been set
-    if (chewieController.progressIndicatorDelayMs != null) {
+    if (chewieController.progressIndicatorDelay != null) {
       if (controller.value.isBuffering) {
         timerInstance ??= Timer(
-          Duration(
-            milliseconds: chewieController.progressIndicatorDelayMs!,
-          ),
+          chewieController.progressIndicatorDelay!,
           handleTimeout,
         );
       } else {

--- a/lib/src/material/material_controls.dart
+++ b/lib/src/material/material_controls.dart
@@ -563,12 +563,22 @@ class _MaterialControlsState extends State<MaterialControls>
   void _updateState() {
     if (!mounted) return;
 
-    if (controller.value.isBuffering) {
-      timerInstance ??= Timer(const Duration(milliseconds: 200), handleTimeout);
+    // display the progress bar indicator only after the buffering delay if it has been set
+    if (chewieController.progressIndicatorDelayMS != null) {
+      if (controller.value.isBuffering) {
+        timerInstance ??= Timer(
+          Duration(
+            milliseconds: chewieController.progressIndicatorDelayMS!,
+          ),
+          handleTimeout,
+        );
+      } else {
+        timerInstance?.cancel();
+        timerInstance = null;
+        displayLoading = false;
+      }
     } else {
-      timerInstance?.cancel();
-      timerInstance = null;
-      displayLoading = false;
+      displayLoading = controller.value.isBuffering;
     }
 
     setState(() {

--- a/lib/src/material/material_controls.dart
+++ b/lib/src/material/material_controls.dart
@@ -82,7 +82,7 @@ class _MaterialControlsState extends State<MaterialControls>
           absorbing: notifier.hideStuff,
           child: Stack(
             children: [
-              if (_latestValue.isBuffering)
+              if (displayLoading)
                 const Center(
                   child: CircularProgressIndicator(),
                 )
@@ -550,8 +550,27 @@ class _MaterialControlsState extends State<MaterialControls>
     });
   }
 
+  Timer? timerInstance;
+  bool displayLoading = false;
+
+  void handleTimeout() {
+    displayLoading = true;
+    if (mounted) {
+      setState(() {});
+    }
+  }
+
   void _updateState() {
     if (!mounted) return;
+
+    if (controller.value.isBuffering) {
+      timerInstance ??= Timer(const Duration(milliseconds: 200), handleTimeout);
+    } else {
+      timerInstance?.cancel();
+      timerInstance = null;
+      displayLoading = false;
+    }
+
     setState(() {
       _latestValue = controller.value;
       _subtitlesPosition = controller.value.position;

--- a/lib/src/material/material_controls.dart
+++ b/lib/src/material/material_controls.dart
@@ -40,6 +40,8 @@ class _MaterialControlsState extends State<MaterialControls>
   Timer? _showAfterExpandCollapseTimer;
   bool _dragging = false;
   bool _displayTapped = false;
+  Timer? _bufferingDisplayTimer;
+  bool _displayBufferingIndicator = false;
 
   final barHeight = 48.0 * 1.5;
   final marginSize = 5.0;
@@ -82,7 +84,7 @@ class _MaterialControlsState extends State<MaterialControls>
           absorbing: notifier.hideStuff,
           child: Stack(
             children: [
-              if (displayLoading)
+              if (_displayBufferingIndicator)
                 const Center(
                   child: CircularProgressIndicator(),
                 )
@@ -550,11 +552,8 @@ class _MaterialControlsState extends State<MaterialControls>
     });
   }
 
-  Timer? timerInstance;
-  bool displayLoading = false;
-
-  void handleTimeout() {
-    displayLoading = true;
+  void _bufferingTimerTimeout() {
+    _displayBufferingIndicator = true;
     if (mounted) {
       setState(() {});
     }
@@ -566,17 +565,17 @@ class _MaterialControlsState extends State<MaterialControls>
     // display the progress bar indicator only after the buffering delay if it has been set
     if (chewieController.progressIndicatorDelay != null) {
       if (controller.value.isBuffering) {
-        timerInstance ??= Timer(
+        _bufferingDisplayTimer ??= Timer(
           chewieController.progressIndicatorDelay!,
-          handleTimeout,
+          _bufferingTimerTimeout,
         );
       } else {
-        timerInstance?.cancel();
-        timerInstance = null;
-        displayLoading = false;
+        _bufferingDisplayTimer?.cancel();
+        _bufferingDisplayTimer = null;
+        _displayBufferingIndicator = false;
       }
     } else {
-      displayLoading = controller.value.isBuffering;
+      _displayBufferingIndicator = controller.value.isBuffering;
     }
 
     setState(() {

--- a/lib/src/material/material_controls.dart
+++ b/lib/src/material/material_controls.dart
@@ -564,11 +564,11 @@ class _MaterialControlsState extends State<MaterialControls>
     if (!mounted) return;
 
     // display the progress bar indicator only after the buffering delay if it has been set
-    if (chewieController.progressIndicatorDelayMS != null) {
+    if (chewieController.progressIndicatorDelayMs != null) {
       if (controller.value.isBuffering) {
         timerInstance ??= Timer(
           Duration(
-            milliseconds: chewieController.progressIndicatorDelayMS!,
+            milliseconds: chewieController.progressIndicatorDelayMs!,
           ),
           handleTimeout,
         );

--- a/lib/src/material/material_desktop_controls.dart
+++ b/lib/src/material/material_desktop_controls.dart
@@ -41,6 +41,8 @@ class _MaterialDesktopControlsState extends State<MaterialDesktopControls>
   Timer? _showAfterExpandCollapseTimer;
   bool _dragging = false;
   bool _displayTapped = false;
+  Timer? _bufferingDisplayTimer;
+  bool _displayBufferingIndicator = false;
 
   final barHeight = 48.0 * 1.5;
   final marginSize = 5.0;
@@ -83,7 +85,7 @@ class _MaterialDesktopControlsState extends State<MaterialDesktopControls>
           absorbing: notifier.hideStuff,
           child: Stack(
             children: [
-              if (_latestValue.isBuffering)
+              if (_displayBufferingIndicator)
                 const Center(
                   child: CircularProgressIndicator(),
                 )
@@ -530,8 +532,32 @@ class _MaterialDesktopControlsState extends State<MaterialDesktopControls>
     });
   }
 
+  void _bufferingTimerTimeout() {
+    _displayBufferingIndicator = true;
+    if (mounted) {
+      setState(() {});
+    }
+  }
+
   void _updateState() {
     if (!mounted) return;
+
+    // display the progress bar indicator only after the buffering delay if it has been set
+    if (chewieController.progressIndicatorDelay != null) {
+      if (controller.value.isBuffering) {
+        _bufferingDisplayTimer ??= Timer(
+          chewieController.progressIndicatorDelay!,
+          _bufferingTimerTimeout,
+        );
+      } else {
+        _bufferingDisplayTimer?.cancel();
+        _bufferingDisplayTimer = null;
+        _displayBufferingIndicator = false;
+      }
+    } else {
+      _displayBufferingIndicator = controller.value.isBuffering;
+    }
+
     setState(() {
       _latestValue = controller.value;
       _subtitlesPosition = controller.value.position;

--- a/lib/src/progress_bar.dart
+++ b/lib/src/progress_bar.dart
@@ -83,13 +83,13 @@ class _VideoProgressBarState extends State<VideoProgressBar> {
         if (!controller.value.isInitialized) {
           return;
         }
-        if (Platform.isAndroid) {
-          // on android, we need to let the player buffer when scrolling
-          // in order to let the player buffer. https://github.com/flutter/flutter/issues/101409
-          if (!controller.value.isBuffering) {
-            _seekToRelativePosition(details.globalPosition);
-          }
-        } else {
+        // Should only seek if it's not running on Android, or if it is,
+        // then the VideoPlayerController cannot be buffering.
+        // On Android, we need to let the player buffer when scrolling
+        // in order to let the player buffer. https://github.com/flutter/flutter/issues/101409
+        final shouldSeekToRelativePosition =
+            !Platform.isAndroid || !controller.value.isBuffering;
+        if (shouldSeekToRelativePosition) {
           _seekToRelativePosition(details.globalPosition);
         }
 

--- a/lib/src/progress_bar.dart
+++ b/lib/src/progress_bar.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:chewie/src/chewie_progress_colors.dart';
 import 'package:flutter/material.dart';
 import 'package:video_player/video_player.dart';
@@ -81,7 +83,15 @@ class _VideoProgressBarState extends State<VideoProgressBar> {
         if (!controller.value.isInitialized) {
           return;
         }
-        _seekToRelativePosition(details.globalPosition);
+        if (Platform.isAndroid) {
+          // on android, we need to let the player buffer when scrolling
+          // in order to let the player buffer. https://github.com/flutter/flutter/issues/101409
+          if (!controller.value.isBuffering) {
+            _seekToRelativePosition(details.globalPosition);
+          }
+        } else {
+          _seekToRelativePosition(details.globalPosition);
+        }
 
         widget.onDragUpdate?.call();
       },

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,11 +12,7 @@ dependencies:
   flutter:
     sdk: flutter
   provider: ^6.0.1
-  video_player:
-    git:
-      url: https://github.com/henri2h/plugins.git
-      ref: henri/enhance-seeking-mechanism-test
-      path: packages/video_player/video_player
+  video_player: ^2.2.7
   wakelock: ^0.6.1+1
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,11 @@ dependencies:
   flutter:
     sdk: flutter
   provider: ^6.0.1
-  video_player: ^2.2.7
+  video_player:
+    git:
+      url: https://github.com/henri2h/plugins.git
+      ref: henri/enhance-seeking-mechanism-test
+      path: packages/video_player/video_player
   wakelock: ^0.6.1+1
 
 dev_dependencies:


### PR DESCRIPTION
After a bit of digging in the `video_player`, I managed to enhance the seeking performance.

However, with this when seeking, it's frequent to have dozen of milliseconds between `STATE_BUFFERING` and `STATE_READY`. This makes the `CircularProgressIndicator` be displayed during a few milliseconds.

To prevent this, we propose to introduce a bit of temporization between the first `isBuffering` status and displaying the `CircularProgressIndicator`.


| Proposal | Actual |
| --- | --- |
|![chewie](https://user-images.githubusercontent.com/13080562/161302766-aa750878-96fe-4031-b745-8a65455a2404.gif)|![schnell](https://user-images.githubusercontent.com/13080562/161302775-52139f22-787e-4ed9-8c1a-d106378d89e9.gif)|

Currently, an arbitrary timeout of 200ms has been chosen.

Linked pull request : https://github.com/flutter/plugins/pull/5145

NB: This proposal only edit the `material_control` version of the player. I can edit the other view if you are willing to accept this proposal.