### PR TITLE
Added customizable timer to hide controls

### DIFF
--- a/example/lib/app/app.dart
+++ b/example/lib/app/app.dart
@@ -133,6 +133,8 @@ class _ChewieDemoState extends State<ChewieDemo> {
               ),
       ),
 
+      hideControlsTimer: const Duration(seconds: 1),
+
       // Try playing around with some of these other options:
 
       // showControls: false,

--- a/lib/src/chewie_player.dart
+++ b/lib/src/chewie_player.dart
@@ -280,7 +280,7 @@ class ChewieController extends ChangeNotifier {
     this.systemOverlaysAfterFullScreen = SystemUiOverlay.values,
     this.deviceOrientationsAfterFullScreen = DeviceOrientation.values,
     this.routePageBuilder,
-    this.hideControlsTimer = defaultTimer,
+    this.hideControlsTimer = defaultHideControlsTimer,
   }) : assert(
           playbackSpeeds.every((speed) => speed > 0),
           'The playbackSpeeds values must all be greater than 0',
@@ -380,7 +380,7 @@ class ChewieController extends ChangeNotifier {
     );
   }
 
-  static const defaultTimer = Duration(seconds: 3);
+  static const defaultHideControlsTimer = Duration(seconds: 3);
 
   /// If false, the options button in MaterialUI and MaterialDesktopUI
   /// won't be shown.

--- a/lib/src/chewie_player.dart
+++ b/lib/src/chewie_player.dart
@@ -492,7 +492,7 @@ class ChewieController extends ChangeNotifier {
   /// Defines if push/pop navigations use the rootNavigator
   final bool useRootNavigator;
 
-  /// Define the time interval before the video controls are hidden
+  /// Defines the time interval before the video controls are hidden. By default, this is three seconds.
   final Duration hideControlsTimer;
 
   /// Defines the set of allowed playback speeds user can change

--- a/lib/src/chewie_player.dart
+++ b/lib/src/chewie_player.dart
@@ -280,6 +280,7 @@ class ChewieController extends ChangeNotifier {
     this.systemOverlaysAfterFullScreen = SystemUiOverlay.values,
     this.deviceOrientationsAfterFullScreen = DeviceOrientation.values,
     this.routePageBuilder,
+    this.hideControlsTimer = const Duration(seconds: 3),
   }) : assert(
           playbackSpeeds.every((speed) => speed > 0),
           'The playbackSpeeds values must all be greater than 0',
@@ -317,6 +318,7 @@ class ChewieController extends ChangeNotifier {
     bool? allowMuting,
     bool? allowPlaybackSpeedChanging,
     bool? useRootNavigator,
+    Duration? hideControlsTimer,
     List<double>? playbackSpeeds,
     List<SystemUiOverlay>? systemOverlaysOnEnterFullScreen,
     List<DeviceOrientation>? deviceOrientationsOnEnterFullScreen,
@@ -374,6 +376,7 @@ class ChewieController extends ChangeNotifier {
       deviceOrientationsAfterFullScreen: deviceOrientationsAfterFullScreen ??
           this.deviceOrientationsAfterFullScreen,
       routePageBuilder: routePageBuilder ?? this.routePageBuilder,
+      hideControlsTimer: hideControlsTimer ?? this.hideControlsTimer,
     );
   }
 
@@ -486,6 +489,9 @@ class ChewieController extends ChangeNotifier {
 
   /// Defines if push/pop navigations use the rootNavigator
   final bool useRootNavigator;
+
+  /// Define the time interval before the video controls are hidden
+  final Duration hideControlsTimer;
 
   /// Defines the set of allowed playback speeds user can change
   final List<double> playbackSpeeds;

--- a/lib/src/chewie_player.dart
+++ b/lib/src/chewie_player.dart
@@ -492,7 +492,7 @@ class ChewieController extends ChangeNotifier {
   /// Defines if push/pop navigations use the rootNavigator
   final bool useRootNavigator;
 
-  /// Defines the time interval before the video controls are hidden. By default, this is three seconds.
+  /// Defines the [Duration] before the video controls are hidden. By default, this is set to three seconds.
   final Duration hideControlsTimer;
 
   /// Defines the set of allowed playback speeds user can change

--- a/lib/src/chewie_player.dart
+++ b/lib/src/chewie_player.dart
@@ -280,7 +280,7 @@ class ChewieController extends ChangeNotifier {
     this.systemOverlaysAfterFullScreen = SystemUiOverlay.values,
     this.deviceOrientationsAfterFullScreen = DeviceOrientation.values,
     this.routePageBuilder,
-    this.hideControlsTimer = const Duration(seconds: 3),
+    this.hideControlsTimer = defaultTimer,
   }) : assert(
           playbackSpeeds.every((speed) => speed > 0),
           'The playbackSpeeds values must all be greater than 0',
@@ -379,6 +379,8 @@ class ChewieController extends ChangeNotifier {
       hideControlsTimer: hideControlsTimer ?? this.hideControlsTimer,
     );
   }
+
+  static const defaultTimer = Duration(seconds: 3);
 
   /// If false, the options button in MaterialUI and MaterialDesktopUI
   /// won't be shown.

--- a/lib/src/cupertino/cupertino_controls.dart
+++ b/lib/src/cupertino/cupertino_controls.dart
@@ -760,7 +760,7 @@ class _CupertinoControlsState extends State<CupertinoControls>
 
   void _startHideTimer() {
     final hideControlsTimer = chewieController.hideControlsTimer.isNegative
-        ? const Duration(seconds: 3)
+        ? ChewieController.defaultTimer
         : chewieController.hideControlsTimer;
     _hideTimer = Timer(hideControlsTimer, () {
       setState(() {

--- a/lib/src/cupertino/cupertino_controls.dart
+++ b/lib/src/cupertino/cupertino_controls.dart
@@ -760,7 +760,7 @@ class _CupertinoControlsState extends State<CupertinoControls>
 
   void _startHideTimer() {
     final hideControlsTimer = chewieController.hideControlsTimer.isNegative
-        ? ChewieController.defaultTimer
+        ? ChewieController.defaultHideControlsTimer
         : chewieController.hideControlsTimer;
     _hideTimer = Timer(hideControlsTimer, () {
       setState(() {

--- a/lib/src/cupertino/cupertino_controls.dart
+++ b/lib/src/cupertino/cupertino_controls.dart
@@ -759,7 +759,10 @@ class _CupertinoControlsState extends State<CupertinoControls>
   }
 
   void _startHideTimer() {
-    _hideTimer = Timer(const Duration(seconds: 3), () {
+    final hideControlsTimer = chewieController.hideControlsTimer.isNegative
+        ? const Duration(seconds: 3)
+        : chewieController.hideControlsTimer;
+    _hideTimer = Timer(hideControlsTimer, () {
       setState(() {
         notifier.hideStuff = true;
       });

--- a/lib/src/material/material_controls.dart
+++ b/lib/src/material/material_controls.dart
@@ -540,7 +540,10 @@ class _MaterialControlsState extends State<MaterialControls>
   }
 
   void _startHideTimer() {
-    _hideTimer = Timer(const Duration(seconds: 3), () {
+    final hideControlsTimer = chewieController.hideControlsTimer.isNegative
+        ? const Duration(seconds: 3)
+        : chewieController.hideControlsTimer;
+    _hideTimer = Timer(hideControlsTimer, () {
       setState(() {
         notifier.hideStuff = true;
       });

--- a/lib/src/material/material_controls.dart
+++ b/lib/src/material/material_controls.dart
@@ -541,7 +541,7 @@ class _MaterialControlsState extends State<MaterialControls>
 
   void _startHideTimer() {
     final hideControlsTimer = chewieController.hideControlsTimer.isNegative
-        ? const Duration(seconds: 3)
+        ? ChewieController.defaultTimer
         : chewieController.hideControlsTimer;
     _hideTimer = Timer(hideControlsTimer, () {
       setState(() {

--- a/lib/src/material/material_controls.dart
+++ b/lib/src/material/material_controls.dart
@@ -541,7 +541,7 @@ class _MaterialControlsState extends State<MaterialControls>
 
   void _startHideTimer() {
     final hideControlsTimer = chewieController.hideControlsTimer.isNegative
-        ? ChewieController.defaultTimer
+        ? ChewieController.defaultHideControlsTimer
         : chewieController.hideControlsTimer;
     _hideTimer = Timer(hideControlsTimer, () {
       setState(() {

--- a/lib/src/material/material_desktop_controls.dart
+++ b/lib/src/material/material_desktop_controls.dart
@@ -521,7 +521,7 @@ class _MaterialDesktopControlsState extends State<MaterialDesktopControls>
 
   void _startHideTimer() {
     final hideControlsTimer = chewieController.hideControlsTimer.isNegative
-        ? const Duration(seconds: 3)
+        ? ChewieController.defaultTimer
         : chewieController.hideControlsTimer;
     _hideTimer = Timer(hideControlsTimer, () {
       setState(() {

--- a/lib/src/material/material_desktop_controls.dart
+++ b/lib/src/material/material_desktop_controls.dart
@@ -521,7 +521,7 @@ class _MaterialDesktopControlsState extends State<MaterialDesktopControls>
 
   void _startHideTimer() {
     final hideControlsTimer = chewieController.hideControlsTimer.isNegative
-        ? ChewieController.defaultTimer
+        ? ChewieController.defaultHideControlsTimer
         : chewieController.hideControlsTimer;
     _hideTimer = Timer(hideControlsTimer, () {
       setState(() {

--- a/lib/src/material/material_desktop_controls.dart
+++ b/lib/src/material/material_desktop_controls.dart
@@ -520,7 +520,10 @@ class _MaterialDesktopControlsState extends State<MaterialDesktopControls>
   }
 
   void _startHideTimer() {
-    _hideTimer = Timer(const Duration(seconds: 3), () {
+    final hideControlsTimer = chewieController.hideControlsTimer.isNegative
+        ? const Duration(seconds: 3)
+        : chewieController.hideControlsTimer;
+    _hideTimer = Timer(hideControlsTimer, () {
       setState(() {
         notifier.hideStuff = true;
       });


### PR DESCRIPTION
The time interval without user interactions after which the controls are hidden is now customizable.
Negative time intervals are ignored, defaulting to a 3 seconds timer. closes #595 