### PR TITLE
chore: Move very_good_analysis to dev_dependencies

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,6 +19,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   lint: ^1.7.2
+  very_good_analysis: ^2.4.0
 
 flutter:
   uses-material-design: true

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,6 @@ dependencies:
   provider: ^6.0.1
   video_player: ^2.2.7
   wakelock: ^0.6.1+1
-  very_good_analysis: ^2.4.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
- Dependency was on wrong place and prevented users of this package from upgrading to `very_good_analysis: 3.0.0`