### PR TITLE
Fix for CenterPlayButton UI bug when using Material 3

### DIFF
--- a/example/lib/app/theme.dart
+++ b/example/lib/app/theme.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 class AppTheme {
   static final light = ThemeData(
     brightness: Brightness.light,
+    useMaterial3: true,
     colorScheme: const ColorScheme.light(secondary: Colors.red),
     disabledColor: Colors.grey.shade400,
     visualDensity: VisualDensity.adaptivePlatformDensity,
@@ -13,6 +14,7 @@ class AppTheme {
     brightness: Brightness.dark,
     colorScheme: const ColorScheme.dark(secondary: Colors.red),
     disabledColor: Colors.grey.shade400,
+    useMaterial3: true,
     visualDensity: VisualDensity.adaptivePlatformDensity,
   );
 }

--- a/lib/chewie.dart
+++ b/lib/chewie.dart
@@ -4,4 +4,5 @@ export 'src/chewie_player.dart';
 export 'src/chewie_progress_colors.dart';
 export 'src/cupertino/cupertino_controls.dart';
 export 'src/material/material_controls.dart';
+export 'src/material/material_desktop_controls.dart';
 export 'src/models/index.dart';

--- a/lib/src/center_play_button.dart
+++ b/lib/src/center_play_button.dart
@@ -21,14 +21,14 @@ class CenterPlayButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
+    return ColoredBox(
       color: Colors.transparent,
       child: Center(
         child: UnconstrainedBox(
           child: AnimatedOpacity(
             opacity: show ? 1.0 : 0.0,
             duration: const Duration(milliseconds: 300),
-            child: Container(
+            child: DecoratedBox(
               decoration: BoxDecoration(
                 color: backgroundColor,
                 shape: BoxShape.circle,

--- a/lib/src/center_play_button.dart
+++ b/lib/src/center_play_button.dart
@@ -24,27 +24,29 @@ class CenterPlayButton extends StatelessWidget {
     return Container(
       color: Colors.transparent,
       child: Center(
-        child: AnimatedOpacity(
-          opacity: show ? 1.0 : 0.0,
-          duration: const Duration(milliseconds: 300),
-          child: Container(
-            decoration: BoxDecoration(
-              color: backgroundColor,
-              shape: BoxShape.circle,
-            ),
-            child: Padding(
-              padding: const EdgeInsets.all(12.0),
-              // Always set the iconSize on the IconButton, not on the Icon itself:
-              // https://github.com/flutter/flutter/issues/52980
-              child: IconButton(
-                iconSize: 32,
-                icon: isFinished
-                    ? Icon(Icons.replay, color: iconColor)
-                    : AnimatedPlayPause(
-                        color: iconColor,
-                        playing: isPlaying,
-                      ),
-                onPressed: onPressed,
+        child: UnconstrainedBox(
+          child: AnimatedOpacity(
+            opacity: show ? 1.0 : 0.0,
+            duration: const Duration(milliseconds: 300),
+            child: Container(
+              decoration: BoxDecoration(
+                color: backgroundColor,
+                shape: BoxShape.circle,
+              ),
+              child: Padding(
+                padding: const EdgeInsets.all(12.0),
+                // Always set the iconSize on the IconButton, not on the Icon itself:
+                // https://github.com/flutter/flutter/issues/52980
+                child: IconButton(
+                  iconSize: 32,
+                  icon: isFinished
+                      ? Icon(Icons.replay, color: iconColor)
+                      : AnimatedPlayPause(
+                          color: iconColor,
+                          playing: isPlaying,
+                        ),
+                  onPressed: onPressed,
+                ),
               ),
             ),
           ),

--- a/lib/src/center_play_button.dart
+++ b/lib/src/center_play_button.dart
@@ -33,20 +33,18 @@ class CenterPlayButton extends StatelessWidget {
                 color: backgroundColor,
                 shape: BoxShape.circle,
               ),
-              child: Padding(
+              // Always set the iconSize on the IconButton, not on the Icon itself:
+              // https://github.com/flutter/flutter/issues/52980
+              child: IconButton(
+                iconSize: 32,
                 padding: const EdgeInsets.all(12.0),
-                // Always set the iconSize on the IconButton, not on the Icon itself:
-                // https://github.com/flutter/flutter/issues/52980
-                child: IconButton(
-                  iconSize: 32,
-                  icon: isFinished
-                      ? Icon(Icons.replay, color: iconColor)
-                      : AnimatedPlayPause(
-                          color: iconColor,
-                          playing: isPlaying,
-                        ),
-                  onPressed: onPressed,
-                ),
+                icon: isFinished
+                    ? Icon(Icons.replay, color: iconColor)
+                    : AnimatedPlayPause(
+                        color: iconColor,
+                        playing: isPlaying,
+                      ),
+                onPressed: onPressed,
               ),
             ),
           ),

--- a/lib/src/cupertino/cupertino_controls.dart
+++ b/lib/src/cupertino/cupertino_controls.dart
@@ -142,11 +142,11 @@ class _CupertinoControlsState extends State<CupertinoControls>
 
   @override
   void didChangeDependencies() {
-    final _oldController = _chewieController;
+    final oldController = _chewieController;
     _chewieController = ChewieController.of(context);
     controller = chewieController.videoPlayerController;
 
-    if (_oldController != chewieController) {
+    if (oldController != chewieController) {
       _dispose();
       _initialize();
     }

--- a/lib/src/cupertino/cupertino_controls.dart
+++ b/lib/src/cupertino/cupertino_controls.dart
@@ -203,14 +203,14 @@ class _CupertinoControlsState extends State<CupertinoControls>
 
   Widget _buildSubtitles(Subtitles subtitles) {
     if (!_subtitleOn) {
-      return Container();
+      return const SizedBox();
     }
     if (_subtitlesPosition == null) {
-      return Container();
+      return const SizedBox();
     }
     final currentSubtitle = subtitles.getByPosition(_subtitlesPosition!);
     if (currentSubtitle.isEmpty) {
-      return Container();
+      return const SizedBox();
     }
 
     if (chewieController.subtitleBuilder != null) {
@@ -395,7 +395,7 @@ class _CupertinoControlsState extends State<CupertinoControls>
           borderRadius: BorderRadius.circular(10.0),
           child: BackdropFilter(
             filter: ui.ImageFilter.blur(sigmaX: 10.0),
-            child: Container(
+            child: ColoredBox(
               color: backgroundColor,
               child: Container(
                 height: barHeight,
@@ -468,7 +468,7 @@ class _CupertinoControlsState extends State<CupertinoControls>
   Widget _buildSubtitleToggle(Color iconColor, double barHeight) {
     //if don't have subtitle hiden button
     if (chewieController.subtitle?.isEmpty ?? true) {
-      return Container();
+      return const SizedBox();
     }
     return GestureDetector(
       onTap: _subtitleToggle,

--- a/lib/src/helpers/adaptive_controls.dart
+++ b/lib/src/helpers/adaptive_controls.dart
@@ -1,5 +1,4 @@
 import 'package:chewie/chewie.dart';
-import 'package:chewie/src/material/material_desktop_controls.dart';
 import 'package:flutter/material.dart';
 
 class AdaptiveControls extends StatelessWidget {

--- a/lib/src/material/material_controls.dart
+++ b/lib/src/material/material_controls.dart
@@ -128,11 +128,11 @@ class _MaterialControlsState extends State<MaterialControls>
 
   @override
   void didChangeDependencies() {
-    final _oldController = _chewieController;
+    final oldController = _chewieController;
     _chewieController = ChewieController.of(context);
     controller = chewieController.videoPlayerController;
 
-    if (_oldController != chewieController) {
+    if (oldController != chewieController) {
       _dispose();
       _initialize();
     }

--- a/lib/src/material/material_controls.dart
+++ b/lib/src/material/material_controls.dart
@@ -213,11 +213,11 @@ class _MaterialControlsState extends State<MaterialControls>
 
   Widget _buildSubtitles(BuildContext context, Subtitles subtitles) {
     if (!_subtitleOn) {
-      return Container();
+      return const SizedBox();
     }
     final currentSubtitle = subtitles.getByPosition(_subtitlesPosition);
     if (currentSubtitle.isEmpty) {
-      return Container();
+      return const SizedBox();
     }
 
     if (chewieController.subtitleBuilder != null) {
@@ -446,7 +446,7 @@ class _MaterialControlsState extends State<MaterialControls>
   Widget _buildSubtitleToggle() {
     //if don't have subtitle hiden button
     if (chewieController.subtitle?.isEmpty ?? true) {
-      return Container();
+      return const SizedBox();
     }
     return GestureDetector(
       onTap: _onSubtitleTap,

--- a/lib/src/material/material_desktop_controls.dart
+++ b/lib/src/material/material_desktop_controls.dart
@@ -206,11 +206,11 @@ class _MaterialDesktopControlsState extends State<MaterialDesktopControls>
 
   Widget _buildSubtitles(BuildContext context, Subtitles subtitles) {
     if (!_subtitleOn) {
-      return Container();
+      return const SizedBox();
     }
     final currentSubtitle = subtitles.getByPosition(_subtitlesPosition);
     if (currentSubtitle.isEmpty) {
-      return Container();
+      return const SizedBox();
     }
 
     if (chewieController.subtitleBuilder != null) {

--- a/lib/src/material/material_desktop_controls.dart
+++ b/lib/src/material/material_desktop_controls.dart
@@ -128,11 +128,11 @@ class _MaterialDesktopControlsState extends State<MaterialDesktopControls>
 
   @override
   void didChangeDependencies() {
-    final _oldController = _chewieController;
+    final oldController = _chewieController;
     _chewieController = ChewieController.of(context);
     controller = chewieController.videoPlayerController;
 
-    if (_oldController != chewieController) {
+    if (oldController != chewieController) {
       _dispose();
       _initialize();
     }

--- a/lib/src/material/widgets/playback_speed_dialog.dart
+++ b/lib/src/material/widgets/playback_speed_dialog.dart
@@ -20,12 +20,12 @@ class PlaybackSpeedDialog extends StatelessWidget {
       shrinkWrap: true,
       physics: const ScrollPhysics(),
       itemBuilder: (context, index) {
-        final _speed = _speeds[index];
+        final speed = _speeds[index];
         return ListTile(
           dense: true,
           title: Row(
             children: [
-              if (_speed == _selected)
+              if (speed == _selected)
                 Icon(
                   Icons.check,
                   size: 20.0,
@@ -34,12 +34,12 @@ class PlaybackSpeedDialog extends StatelessWidget {
               else
                 Container(width: 20.0),
               const SizedBox(width: 16.0),
-              Text(_speed.toString()),
+              Text(speed.toString()),
             ],
           ),
-          selected: _speed == _selected,
+          selected: speed == _selected,
           onTap: () {
-            Navigator.of(context).pop(_speed);
+            Navigator.of(context).pop(speed);
           },
         );
       },

--- a/lib/src/player_with_controls.dart
+++ b/lib/src/player_with_controls.dart
@@ -12,7 +12,7 @@ class PlayerWithControls extends StatelessWidget {
   Widget build(BuildContext context) {
     final ChewieController chewieController = ChewieController.of(context);
 
-    double _calculateAspectRatio(BuildContext context) {
+    double calculateAspectRatio(BuildContext context) {
       final size = MediaQuery.of(context).size;
       final width = size.width;
       final height = size.height;
@@ -20,7 +20,7 @@ class PlayerWithControls extends StatelessWidget {
       return width > height ? width / height : height / width;
     }
 
-    Widget _buildControls(
+    Widget buildControls(
       BuildContext context,
       ChewieController chewieController,
     ) {
@@ -29,7 +29,7 @@ class PlayerWithControls extends StatelessWidget {
           : const SizedBox();
     }
 
-    Widget _buildPlayerWithControls(
+    Widget buildPlayerWithControls(
       ChewieController chewieController,
       BuildContext context,
     ) {
@@ -73,11 +73,11 @@ class PlayerWithControls extends StatelessWidget {
               ),
             ),
           if (!chewieController.isFullScreen)
-            _buildControls(context, chewieController)
+            buildControls(context, chewieController)
           else
             SafeArea(
               bottom: false,
-              child: _buildControls(context, chewieController),
+              child: buildControls(context, chewieController),
             ),
         ],
       );
@@ -88,8 +88,8 @@ class PlayerWithControls extends StatelessWidget {
         height: MediaQuery.of(context).size.height,
         width: MediaQuery.of(context).size.width,
         child: AspectRatio(
-          aspectRatio: _calculateAspectRatio(context),
-          child: _buildPlayerWithControls(chewieController, context),
+          aspectRatio: calculateAspectRatio(context),
+          child: buildPlayerWithControls(chewieController, context),
         ),
       ),
     );

--- a/lib/src/player_with_controls.dart
+++ b/lib/src/player_with_controls.dart
@@ -26,7 +26,7 @@ class PlayerWithControls extends StatelessWidget {
     ) {
       return chewieController.showControls
           ? chewieController.customControls ?? const AdaptiveControls()
-          : Container();
+          : const SizedBox();
     }
 
     Widget _buildPlayerWithControls(
@@ -65,9 +65,9 @@ class PlayerWithControls extends StatelessWidget {
                   duration: const Duration(
                     milliseconds: 250,
                   ),
-                  child: Container(
-                    decoration: const BoxDecoration(color: Colors.black54),
-                    child: Container(),
+                  child: const DecoratedBox(
+                    decoration: BoxDecoration(color: Colors.black54),
+                    child: SizedBox(),
                   ),
                 ),
               ),


### PR DESCRIPTION
When using Material 3, the AnimatedOpacity of **CenterPlayButton** expands to fill the available space, and looks like this:

![IMG_0638](https://user-images.githubusercontent.com/28322469/188929975-40529e44-7324-4e3f-8302-e4e73948f022.PNG)

This PR fixes it, and in addition:
- It exposes MaterialDesktopControls to allow devs to explicitly use it.
- Some lints fixed for better performance