### PR TITLE
Flutter 3.3 lint fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,25 +1,28 @@
 name: CI
 
 on:
+  pull_request:
+    paths-ignore:
+      - '**.md'
   push:
     branches:
-    - master
-  pull_request:
+      - master
+    paths-ignore:
+      - '**.md'
   workflow_dispatch:
 
 jobs:
   check-format:
-      name: Check format using flutter format .
+      name: Check format using flutter format.
       runs-on: ubuntu-latest
 
       steps:
         - name: Checkout code
           uses: actions/checkout@v2
-        - uses: subosito/flutter-action@v1
-          with:
-            channel: beta
+        - name: Flutter Action
+          uses: subosito/flutter-action@v2
         - name: Check format
-          run: flutter format -n . --set-exit-if-changed
+          run: flutter format . --set-exit-if-changed
 
   lint:
     name: Lint
@@ -28,14 +31,15 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - uses: subosito/flutter-action@v1
-        with:
-          channel: beta
+      - name: Flutter Action
+        uses: subosito/flutter-action@v2
+      - name: Install Package Dependencies
+        run: flutter packages get
       - name: Get dependencies for example
         run: flutter pub get
         working-directory: example
       - name: Lint using flutter analyze
-        run: flutter analyze
+        run: flutter analyze .
 
   # test:
   #   name: Test2

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,4 +1,4 @@
-include: package:lint/analysis_options_package.yaml
+include: package:flutter_lints/flutter.yaml
 
 analyzer:
   strong-mode:

--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -1,4 +1,4 @@
-include: package:lint/analysis_options_package.yaml
+include: package:flutter_lints/flutter.yaml
 
 analyzer:
   strong-mode:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  lint: ^1.8.2
+  flutter_lints: ^2.0.1
 
 # For information on the generic Dart part of this file, see the
 # following page: https://www.dartlang.org/tools/pub/pubspec

--- a/lib/src/chewie_player.dart
+++ b/lib/src/chewie_player.dart
@@ -625,6 +625,6 @@ class ChewieControllerProvider extends InheritedWidget {
   final ChewieController controller;
 
   @override
-  bool updateShouldNotify(ChewieControllerProvider old) =>
-      controller != old.controller;
+  bool updateShouldNotify(ChewieControllerProvider oldWidget) =>
+      controller != oldWidget.controller;
 }

--- a/lib/src/cupertino/cupertino_controls.dart
+++ b/lib/src/cupertino/cupertino_controls.dart
@@ -142,11 +142,11 @@ class _CupertinoControlsState extends State<CupertinoControls>
 
   @override
   void didChangeDependencies() {
-    final _oldController = _chewieController;
+    final oldController = _chewieController;
     _chewieController = ChewieController.of(context);
     controller = chewieController.videoPlayerController;
 
-    if (_oldController != chewieController) {
+    if (oldController != chewieController) {
       _dispose();
       _initialize();
     }

--- a/lib/src/material/material_controls.dart
+++ b/lib/src/material/material_controls.dart
@@ -128,11 +128,11 @@ class _MaterialControlsState extends State<MaterialControls>
 
   @override
   void didChangeDependencies() {
-    final _oldController = _chewieController;
+    final oldController = _chewieController;
     _chewieController = ChewieController.of(context);
     controller = chewieController.videoPlayerController;
 
-    if (_oldController != chewieController) {
+    if (oldController != chewieController) {
       _dispose();
       _initialize();
     }

--- a/lib/src/material/material_desktop_controls.dart
+++ b/lib/src/material/material_desktop_controls.dart
@@ -128,11 +128,11 @@ class _MaterialDesktopControlsState extends State<MaterialDesktopControls>
 
   @override
   void didChangeDependencies() {
-    final _oldController = _chewieController;
+    final oldController = _chewieController;
     _chewieController = ChewieController.of(context);
     controller = chewieController.videoPlayerController;
 
-    if (_oldController != chewieController) {
+    if (oldController != chewieController) {
       _dispose();
       _initialize();
     }

--- a/lib/src/material/widgets/playback_speed_dialog.dart
+++ b/lib/src/material/widgets/playback_speed_dialog.dart
@@ -20,12 +20,12 @@ class PlaybackSpeedDialog extends StatelessWidget {
       shrinkWrap: true,
       physics: const ScrollPhysics(),
       itemBuilder: (context, index) {
-        final _speed = _speeds[index];
+        final speed = _speeds[index];
         return ListTile(
           dense: true,
           title: Row(
             children: [
-              if (_speed == _selected)
+              if (speed == _selected)
                 Icon(
                   Icons.check,
                   size: 20.0,
@@ -34,12 +34,12 @@ class PlaybackSpeedDialog extends StatelessWidget {
               else
                 Container(width: 20.0),
               const SizedBox(width: 16.0),
-              Text(_speed.toString()),
+              Text(speed.toString()),
             ],
           ),
-          selected: _speed == _selected,
+          selected: speed == _selected,
           onTap: () {
-            Navigator.of(context).pop(_speed);
+            Navigator.of(context).pop(speed);
           },
         );
       },

--- a/lib/src/models/subtitle_model.dart
+++ b/lib/src/models/subtitle_model.dart
@@ -50,14 +50,14 @@ class Subtitle {
   }
 
   @override
-  bool operator ==(Object o) {
-    if (identical(this, o)) return true;
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
 
-    return o is Subtitle &&
-        o.index == index &&
-        o.start == start &&
-        o.end == end &&
-        o.text == text;
+    return other is Subtitle &&
+        other.index == index &&
+        other.start == start &&
+        other.end == end &&
+        other.text == text;
   }
 
   @override

--- a/lib/src/player_with_controls.dart
+++ b/lib/src/player_with_controls.dart
@@ -12,7 +12,7 @@ class PlayerWithControls extends StatelessWidget {
   Widget build(BuildContext context) {
     final ChewieController chewieController = ChewieController.of(context);
 
-    double _calculateAspectRatio(BuildContext context) {
+    double calculateAspectRatio(BuildContext context) {
       final size = MediaQuery.of(context).size;
       final width = size.width;
       final height = size.height;
@@ -20,7 +20,7 @@ class PlayerWithControls extends StatelessWidget {
       return width > height ? width / height : height / width;
     }
 
-    Widget _buildControls(
+    Widget buildControls(
       BuildContext context,
       ChewieController chewieController,
     ) {
@@ -29,7 +29,7 @@ class PlayerWithControls extends StatelessWidget {
           : Container();
     }
 
-    Widget _buildPlayerWithControls(
+    Widget buildPlayerWithControls(
       ChewieController chewieController,
       BuildContext context,
     ) {
@@ -73,11 +73,11 @@ class PlayerWithControls extends StatelessWidget {
               ),
             ),
           if (!chewieController.isFullScreen)
-            _buildControls(context, chewieController)
+            buildControls(context, chewieController)
           else
             SafeArea(
               bottom: false,
-              child: _buildControls(context, chewieController),
+              child: buildControls(context, chewieController),
             ),
         ],
       );
@@ -88,8 +88,8 @@ class PlayerWithControls extends StatelessWidget {
         height: MediaQuery.of(context).size.height,
         width: MediaQuery.of(context).size.width,
         child: AspectRatio(
-          aspectRatio: _calculateAspectRatio(context),
-          child: _buildPlayerWithControls(chewieController, context),
+          aspectRatio: calculateAspectRatio(context),
+          child: buildPlayerWithControls(chewieController, context),
         ),
       ),
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,8 +18,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  lint: ^1.8.2
-  very_good_analysis: ^3.0.0
+  flutter_lints: ^2.0.1
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
Library and Example App are now using `flutter_lints`.

Addresses any outstanding Dart Analysis issues as a result. Mostly just renaming variables.