### PR TITLE
Fix : fullScreenByDefault does not work with autoPlay #710

### DIFF
--- a/lib/src/chewie_player.dart
+++ b/lib/src/chewie_player.dart
@@ -561,16 +561,17 @@ class ChewieController extends ChangeNotifier {
     }
 
     if (fullScreenByDefault) {
-      videoPlayerController.addListener(_fullScreenByDefaultListener);
+      videoPlayerController.addListener(_tryToEnableFullScreen);
     }
   }
 
-  Future<void> _fullScreenByDefaultListener() async {
-    if (videoPlayerController.value.isPlaying &&
-        fullScreenByDefault &&
-        !_isFullScreen) {
+  Future<void> _tryToEnableFullScreen() async {
+    if (fullScreenByDefault &&
+        _isFullScreen == false &&
+        videoPlayerController.value.isPlaying &&
+        hasListeners) {
       enterFullScreen();
-      videoPlayerController.removeListener(_fullScreenByDefaultListener);
+      videoPlayerController.removeListener(_tryToEnableFullScreen);
     }
   }
 

--- a/lib/src/chewie_player.dart
+++ b/lib/src/chewie_player.dart
@@ -553,10 +553,6 @@ class ChewieController extends ChangeNotifier {
     }
 
     if (autoPlay) {
-      if (fullScreenByDefault) {
-        enterFullScreen();
-      }
-
       await videoPlayerController.play();
     }
 
@@ -565,14 +561,16 @@ class ChewieController extends ChangeNotifier {
     }
 
     if (fullScreenByDefault) {
-      videoPlayerController.addListener(_fullScreenListener);
+      videoPlayerController.addListener(_fullScreenByDefaultListener);
     }
   }
 
-  Future<void> _fullScreenListener() async {
-    if (videoPlayerController.value.isPlaying && !_isFullScreen) {
+  Future<void> _fullScreenByDefaultListener() async {
+    if (videoPlayerController.value.isPlaying &&
+        fullScreenByDefault &&
+        !_isFullScreen) {
       enterFullScreen();
-      videoPlayerController.removeListener(_fullScreenListener);
+      videoPlayerController.removeListener(_fullScreenByDefaultListener);
     }
   }
 


### PR DESCRIPTION
The first attempt to go full screen just after checking if `autoPlay` is on fails and prevents the second want to be done.

See bug reported here for more information https://github.com/fluttercommunity/chewie/issues/710