### PR TITLE
Fix overlay not visible

### DIFF
--- a/lib/src/player_with_controls.dart
+++ b/lib/src/player_with_controls.dart
@@ -67,7 +67,7 @@ class PlayerWithControls extends StatelessWidget {
                   ),
                   child: const DecoratedBox(
                     decoration: BoxDecoration(color: Colors.black54),
-                    child: SizedBox(),
+                    child: SizedBox.expand(),
                   ),
                 ),
               ),


### PR DESCRIPTION
Causes usability issues, when controls are similar color as the video

Broken since v1.3.5

| master | fix/overlay |
|--------|--------|
| <img width="482" alt="currently" src="https://user-images.githubusercontent.com/10659247/234490239-343f4977-51a8-48ca-ba79-57b5eb19c000.png"> | <img width="482" alt="fixed" src="https://user-images.githubusercontent.com/10659247/234490280-32cb2595-a8ea-45d8-8862-4ee38c99994a.png"> |

