### PR TITLE
Wakelock Plus Migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.6.0
+* [#747](https://github.com/fluttercommunity/chewie/pull/747): Migrated from `wakelock` to `wakelock_plus`. Thanks [diegotori](https://github.com/diegotori).
+* Also upgrades `video_player` from `2.4.7` to `2.7.0`.
+
 ## 1.5.0
 * 🛠️ [#712](https://github.com/fluttercommunity/chewie/pull/712): Progress Bars can now be disabled by setting `ChewieController.draggableProgressBar` to `false`. Thanks [shiyiya](https://github.com/shiyiya).
 * ⬆️ Increased Dart SDK constraint to cover Dart `3.0.0` and higher.

--- a/example/lib/app/app.dart
+++ b/example/lib/app/app.dart
@@ -49,9 +49,9 @@ class _ChewieDemoState extends State<ChewieDemo> {
 
   Future<void> initializePlayer() async {
     _videoPlayerController1 =
-        VideoPlayerController.network(srcs[currPlayIndex]);
+        VideoPlayerController.networkUrl(Uri.parse(srcs[currPlayIndex]));
     _videoPlayerController2 =
-        VideoPlayerController.network(srcs[currPlayIndex]);
+        VideoPlayerController.networkUrl(Uri.parse(srcs[currPlayIndex]));
     await Future.wait([
       _videoPlayerController1.initialize(),
       _videoPlayerController2.initialize()

--- a/lib/src/chewie_player.dart
+++ b/lib/src/chewie_player.dart
@@ -10,7 +10,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 import 'package:video_player/video_player.dart';
-import 'package:wakelock/wakelock.dart';
+import 'package:wakelock_plus/wakelock_plus.dart';
 
 typedef ChewieRoutePageBuilder = Widget Function(
   BuildContext context,
@@ -158,7 +158,7 @@ class ChewieState extends State<Chewie> {
     onEnterFullScreen();
 
     if (!widget.controller.allowedScreenSleep) {
-      Wakelock.enable();
+      WakelockPlus.enable();
     }
 
     await Navigator.of(
@@ -169,8 +169,8 @@ class ChewieState extends State<Chewie> {
     widget.controller.exitFullScreen();
 
     // The wakelock plugins checks whether it needs to perform an action internally,
-    // so we do not need to check Wakelock.isEnabled.
-    Wakelock.disable();
+    // so we do not need to check WakelockPlus.isEnabled.
+    WakelockPlus.disable();
 
     SystemChrome.setEnabledSystemUIMode(
       SystemUiMode.manual,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,24 +1,24 @@
 name: chewie
 description: A video player for Flutter with Cupertino and Material play controls
-version: 1.5.0
+version: 1.6.0
 homepage: https://github.com/fluttercommunity/chewie
 
 environment:
-  sdk: '>=2.13.0 <4.0.0'
-  flutter: '>=1.22.0'
+  sdk: '>=2.17.0 <4.0.0'
+  flutter: ">=2.11.0"
 
 dependencies:
   cupertino_icons: ^1.0.5
   flutter:
     sdk: flutter
-  provider: ^6.0.3
-  video_player: ^2.4.7
-  wakelock: ^0.6.2
+  provider: ^6.0.5
+  video_player: ^2.7.0
+  wakelock_plus: ^1.0.0+2
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^2.0.1
+  flutter_lints: ^2.0.2
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
Migrated `wakelock` to `wakelock_plus`. Also upgraded all other dependencies.

Also increased the minimum supported Flutter version to `2.11.0`.

Addresses #729.