### PR TITLE
Update Dart SDK to version 3

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,8 +4,8 @@ version: 1.6.0+1
 homepage: https://github.com/fluttercommunity/chewie
 
 environment:
-  sdk: '>=2.17.0 <4.0.0'
-  flutter: ">=2.11.0"
+  sdk: '>=3.0.0 <4.0.0'
+  flutter: ">=3.10.0"
 
 dependencies:
   cupertino_icons: ^1.0.5


### PR DESCRIPTION
The chewie package only builds successfully with Dart SDK 3.0. This commit updates the documentation to be reflected on pub.dev. This commit does not change the fact that the package fails to build under Dart SDK 2.17 - 2.19.

Issue https://github.com/fluttercommunity/chewie/issues/752