### PR TITLE
Adding Watermark Feature: Allow Adding Watermark Widgets to Videos

### DIFF
--- a/lib/src/chewie_player.dart
+++ b/lib/src/chewie_player.dart
@@ -246,6 +246,7 @@ class ChewieState extends State<Chewie> {
 class ChewieController extends ChangeNotifier {
   ChewieController({
     required this.videoPlayerController,
+    this.watermark,
     this.optionsTranslation,
     this.aspectRatio,
     this.autoInitialize = false,
@@ -332,6 +333,7 @@ class ChewieController extends ChangeNotifier {
     List<SystemUiOverlay>? systemOverlaysAfterFullScreen,
     List<DeviceOrientation>? deviceOrientationsAfterFullScreen,
     Duration? progressIndicatorDelay,
+    Widget? watermark,
     Widget Function(
       BuildContext,
       Animation<double>,
@@ -340,6 +342,7 @@ class ChewieController extends ChangeNotifier {
     )? routePageBuilder,
   }) {
     return ChewieController(
+      watermark: watermark?? this.watermark,
       draggableProgressBar: draggableProgressBar ?? this.draggableProgressBar,
       videoPlayerController:
           videoPlayerController ?? this.videoPlayerController,
@@ -535,6 +538,9 @@ class ChewieController extends ChangeNotifier {
   /// Adds additional padding to the controls' [SafeArea] as desired.
   /// Defaults to [EdgeInsets.zero].
   final EdgeInsets controlsSafeAreaMinimum;
+
+  ///  adds a watermark as a widget to the video
+   Widget? watermark;
 
   static ChewieController of(BuildContext context) {
     final chewieControllerProvider =

--- a/lib/src/cupertino/cupertino_controls.dart
+++ b/lib/src/cupertino/cupertino_controls.dart
@@ -93,6 +93,10 @@ class _CupertinoControlsState extends State<CupertinoControls>
           absorbing: notifier.hideStuff,
           child: Stack(
             children: [
+              if (chewieController.watermark != null) ...[
+                chewieController.watermark!,
+              ],
+
               if (_displayBufferingIndicator)
                 const Center(
                   child: CircularProgressIndicator(),

--- a/lib/src/material/material_controls.dart
+++ b/lib/src/material/material_controls.dart
@@ -83,7 +83,11 @@ class _MaterialControlsState extends State<MaterialControls>
         child: AbsorbPointer(
           absorbing: notifier.hideStuff,
           child: Stack(
+            alignment: AlignmentDirectional.topCenter,
             children: [
+              if (chewieController.watermark != null) ...[
+                chewieController.watermark!,
+              ],
               if (_displayBufferingIndicator)
                 const Center(
                   child: CircularProgressIndicator(),


### PR DESCRIPTION
Changes Made:

Added a new watermark feature that allows users to add watermark widgets to videos.
Extended the existing classes to accommodate watermark rendering and positioning.

How to Use:
simply any one can add a watermark like that:

_chewieController!.watermark = const Center(child: Text("Hello Watermark Widget",style: TextStyle(color: Colors.white),));


Benefits:
Sometimes the requirements of the application require some security for the video and knowing a specific sign indicating the source of the video leak
It is just to increase safety

Thanks for your time and support
Best regards,
Amr Hassan