### PR TITLE
Stop force disabling wakelock

### DIFF
--- a/lib/src/chewie_player.dart
+++ b/lib/src/chewie_player.dart
@@ -168,9 +168,9 @@ class ChewieState extends State<Chewie> {
     _isFullScreen = false;
     widget.controller.exitFullScreen();
 
-    // The wakelock plugins checks whether it needs to perform an action internally,
-    // so we do not need to check WakelockPlus.isEnabled.
-    WakelockPlus.disable();
+    if (!widget.controller.allowedScreenSleep) {
+      WakelockPlus.disable();
+    }
 
     SystemChrome.setEnabledSystemUIMode(
       SystemUiMode.manual,


### PR DESCRIPTION
This commit addresses the issue where Chewie will force disable Wakelock without taking into account that other packages / app parts might depend on the same package.

In my case, the screen will be able to sleep again after exiting fullscreen, even though we don't want it to while the player is running.

Edit: If needed, for context as to why I removed the comment above the code. It was relevant over 3 years ago, when "sleep" was replaced with Wakelock and a comment was written to explain why the if statement was removed. Yes, we don't have to check if wakelock is enabled anymore, but we should still check if we were the ones that enabled it and not override any custom implementations an app may have.