### PR TITLE
fix display size while Chewie wrapped by some rotate widget

### DIFF
--- a/lib/src/player_with_controls.dart
+++ b/lib/src/player_with_controls.dart
@@ -83,15 +83,18 @@ class PlayerWithControls extends StatelessWidget {
       );
     }
 
-    return Center(
-      child: SizedBox(
-        height: MediaQuery.of(context).size.height,
-        width: MediaQuery.of(context).size.width,
-        child: AspectRatio(
-          aspectRatio: calculateAspectRatio(context),
-          child: buildPlayerWithControls(chewieController, context),
+    return LayoutBuilder(
+        builder: (BuildContext context, BoxConstraints constraints) {
+      return Center(
+        child: SizedBox(
+          height: constraints.maxHeight,
+          width: constraints.maxWidth,
+          child: AspectRatio(
+            aspectRatio: calculateAspectRatio(context),
+            child: buildPlayerWithControls(chewieController, context),
+          ),
         ),
-      ),
-    );
+      );
+    });
   }
 }


### PR DESCRIPTION
When Chewie wrapped by RotatedBox like this. It is used in the situation that device not support landscape and portrait switch.
```
RotatedBox(quarterTurns: 1,
                      child: Chewie(
                        controller: _chewieController!,
                      ))
```
It will not occupy all the space.
![S1](https://github.com/fluttercommunity/chewie/assets/3355710/a7fbccc1-7d0c-462f-9226-60e6d5ef9fd0)

Use LayoutBuilder instead of MediaQuery is more adaptive. It looks like this now.
![s2](https://github.com/fluttercommunity/chewie/assets/3355710/6f523911-9df2-4de4-aa4f-65a2d96661cd)





