### PR TITLE
Fix(example): Toggle video source many times throws PlatformException on Android

### DIFF
--- a/example/lib/app/app.dart
+++ b/example/lib/app/app.dart
@@ -165,6 +165,9 @@ class _ChewieDemoState extends State<ChewieDemo> {
     if (currPlayIndex >= srcs.length) {
       currPlayIndex = 0;
     }
+    _videoPlayerController1.dispose();
+    _videoPlayerController2.dispose();
+    _chewieController?.dispose();
     await initializePlayer();
   }
 


### PR DESCRIPTION
I runned the package last version (1.7.1) example in my device  (Poco F1) and if I press the "toggle video src" button about 8 times, it throws the PlatformException above:
![Screenshot 2023-10-03 at 14 32 42](https://github.com/fluttercommunity/chewie/assets/127892144/4551c2c2-cb56-497d-9dee-a4b355e54a3b)

I noticed that `toggleVideo` function calls `initializePlayer`, but without dispose controllers.

So, dispose controllers before reinitialize fix this problem.

```
[✓] Flutter (Channel stable, 3.13.6, on macOS 13.4.1 22F770820d darwin-arm64,
    locale en-BR)
    • Flutter version 3.13.6 on channel stable at
      /Users/magnocastromoraes/Development/sdks/flutter
    • Upstream repository https://github.com/flutter/flutter.git
    • Framework revision ead455963c (7 days ago), 2023-09-26 18:28:17 -0700
    • Engine revision a794cf2681
    • Dart version 3.1.3
    • DevTools version 2.25.0

[✓] Android toolchain - develop for Android devices (Android SDK version 33.0.1)
    • Android SDK at /Users/magnocastromoraes/Development/sdks/android
    • Platform android-33, build-tools 33.0.1
    • ANDROID_HOME = /Users/magnocastromoraes/Development/sdks/android
    • ANDROID_SDK_ROOT = /Users/magnocastromoraes/Development/sdks/android
    • Java binary at: /Applications/Android
      Studio.app/Contents/jre/Contents/Home/bin/java
    • Java version OpenJDK Runtime Environment (build
      11.0.13+0-b1751.21-8125866)
    • All Android licenses accepted.

[✓] Xcode - develop for iOS and macOS (Xcode 14.3)
    • Xcode at /Applications/Xcode.app/Contents/Developer
    • Build 14E222b
    • CocoaPods version 1.12.0

[✓] Chrome - develop for the web
    • Chrome at /Applications/Google Chrome.app/Contents/MacOS/Google Chrome

[✓] Android Studio (version 2021.3)
    • Android Studio at /Applications/Android Studio.app/Contents
    • Flutter plugin can be installed from:
      🔨 https://plugins.jetbrains.com/plugin/9212-flutter
    • Dart plugin can be installed from:
      🔨 https://plugins.jetbrains.com/plugin/6351-dart
    • Java version OpenJDK Runtime Environment (build
      11.0.13+0-b1751.21-8125866)

[✓] VS Code (version 1.82.2)
    • VS Code at /Applications/Visual Studio Code.app/Contents
    • Flutter extension version 3.75.20231002

[✓] Connected device (3 available)
    • POCOPHONE F1 (mobile) • 50013f86 • android-arm64  • Android 10 (API 29)
    • macOS (desktop)       • macos    • darwin-arm64   • macOS 13.4.1
      22F770820d darwin-arm64
    • Chrome (web)          • chrome   • web-javascript • Google Chrome
      117.0.5938.132

[✓] Network resources
    • All expected network resources are available.
```