### PR TITLE
Manually select desired controls

### DIFF
--- a/lib/chewie.dart
+++ b/lib/chewie.dart
@@ -6,3 +6,4 @@ export 'src/cupertino/cupertino_controls.dart';
 export 'src/material/material_controls.dart';
 export 'src/material/material_desktop_controls.dart';
 export 'src/models/index.dart';
+export 'src/helpers/adaptive_controls.dart';

--- a/lib/src/chewie_player.dart
+++ b/lib/src/chewie_player.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:chewie/src/chewie_progress_colors.dart';
+import 'package:chewie/src/helpers/adaptive_controls.dart';
 import 'package:chewie/src/models/option_item.dart';
 import 'package:chewie/src/models/options_translation.dart';
 import 'package:chewie/src/models/subtitle_model.dart';
@@ -285,6 +286,7 @@ class ChewieController extends ChangeNotifier {
     this.progressIndicatorDelay,
     this.hideControlsTimer = defaultHideControlsTimer,
     this.controlsSafeAreaMinimum = EdgeInsets.zero,
+    this.controlsType = ControlsType.adaptive,
   }) : assert(
           playbackSpeeds.every((speed) => speed > 0),
           'The playbackSpeeds values must all be greater than 0',
@@ -332,6 +334,7 @@ class ChewieController extends ChangeNotifier {
     List<SystemUiOverlay>? systemOverlaysAfterFullScreen,
     List<DeviceOrientation>? deviceOrientationsAfterFullScreen,
     Duration? progressIndicatorDelay,
+    ControlsType? controlsType,
     Widget Function(
       BuildContext,
       Animation<double>,
@@ -387,6 +390,7 @@ class ChewieController extends ChangeNotifier {
       hideControlsTimer: hideControlsTimer ?? this.hideControlsTimer,
       progressIndicatorDelay:
           progressIndicatorDelay ?? this.progressIndicatorDelay,
+      controlsType: controlsType ?? this.controlsType
     );
   }
 
@@ -531,6 +535,9 @@ class ChewieController extends ChangeNotifier {
 
   /// Defines a delay in milliseconds between entering buffering state and displaying the loading spinner. Set null (default) to disable it.
   final Duration? progressIndicatorDelay;
+
+  /// Defines the type of controls (Ex: Material or Cupertino)
+  final ControlsType controlsType;
 
   /// Adds additional padding to the controls' [SafeArea] as desired.
   /// Defaults to [EdgeInsets.zero].

--- a/lib/src/helpers/adaptive_controls.dart
+++ b/lib/src/helpers/adaptive_controls.dart
@@ -1,13 +1,32 @@
 import 'package:chewie/chewie.dart';
 import 'package:flutter/material.dart';
 
+enum ControlsType { cupertino, material, materialDesktop, adaptive }
+
 class AdaptiveControls extends StatelessWidget {
   const AdaptiveControls({
     Key? key,
+    required this.controlsType,
   }) : super(key: key);
+
+  final ControlsType controlsType;
 
   @override
   Widget build(BuildContext context) {
+    switch (controlsType) {
+      case ControlsType.cupertino:
+        return const CupertinoControls(
+          backgroundColor: Color.fromRGBO(41, 41, 41, 0.7),
+          iconColor: Color.fromARGB(255, 200, 200, 200),
+        );
+      case ControlsType.material:
+        return const MaterialControls();
+      case ControlsType.materialDesktop:
+        return const MaterialDesktopControls();
+      case ControlsType.adaptive:
+        break;
+    }
+
     switch (Theme.of(context).platform) {
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:

--- a/lib/src/player_with_controls.dart
+++ b/lib/src/player_with_controls.dart
@@ -25,7 +25,10 @@ class PlayerWithControls extends StatelessWidget {
       ChewieController chewieController,
     ) {
       return chewieController.showControls
-          ? chewieController.customControls ?? const AdaptiveControls()
+          ? chewieController.customControls ??
+              AdaptiveControls(
+                controlsType: chewieController.controlsType,
+              )
           : const SizedBox();
     }
 
@@ -35,8 +38,7 @@ class PlayerWithControls extends StatelessWidget {
     ) {
       return Stack(
         children: <Widget>[
-          if (chewieController.placeholder != null)
-            chewieController.placeholder!,
+          if (chewieController.placeholder != null) chewieController.placeholder!,
           InteractiveViewer(
             transformationController: chewieController.transformationController,
             maxScale: chewieController.maxScale,
@@ -44,8 +46,7 @@ class PlayerWithControls extends StatelessWidget {
             scaleEnabled: chewieController.zoomAndPan,
             child: Center(
               child: AspectRatio(
-                aspectRatio: chewieController.aspectRatio ??
-                    chewieController.videoPlayerController.value.aspectRatio,
+                aspectRatio: chewieController.aspectRatio ?? chewieController.videoPlayerController.value.aspectRatio,
                 child: VideoPlayer(chewieController.videoPlayerController),
               ),
             ),


### PR DESCRIPTION
Currently, the controls are displayed based on the platform, and there's an option to choose build custom controls. But there's no option to use Cupertino controls as default if I want.

Added a high-level attribute to select desired controls type