### PR TITLE
Fix: Progress bar does not follow drag #789

### DIFF
--- a/lib/src/material/widgets/options_dialog.dart
+++ b/lib/src/material/widgets/options_dialog.dart
@@ -28,9 +28,7 @@ class _OptionsDialogState extends State<OptionsDialog> {
             itemCount: widget.options.length,
             itemBuilder: (context, i) {
               return ListTile(
-                onTap: widget.options[i].onTap != null
-                    ? widget.options[i].onTap!
-                    : null,
+                onTap: widget.options[i].onTap,
                 leading: Icon(widget.options[i].iconData),
                 title: Text(widget.options[i].title),
                 subtitle: widget.options[i].subtitle != null

--- a/lib/src/progress_bar.dart
+++ b/lib/src/progress_bar.dart
@@ -266,7 +266,7 @@ extension RelativePositionExtensions on BuildContext {
     if (globalPosition == null) return null;
     final box = findRenderObject()! as RenderBox;
     final Offset tapPos = box.globalToLocal(globalPosition);
-    final double relative = tapPos.dx / box.size.width;
+    final double relative = (tapPos.dx / box.size.width).clamp(0, 1);
     final Duration position = videoDuration * relative;
     return position;
   }

--- a/lib/src/progress_bar.dart
+++ b/lib/src/progress_bar.dart
@@ -58,11 +58,10 @@ class _VideoProgressBarState extends State<VideoProgressBar> {
   }
 
   void _seekToRelativePosition(Offset globalPosition) {
-    final relativePosition = context.calcRelativePosition(
+    controller.seekTo(context.calcRelativePosition(
       controller.value.duration,
       globalPosition,
-    );
-    controller.seekTo(relativePosition ?? Duration.zero);
+    ));
   }
 
   @override
@@ -153,10 +152,12 @@ class StaticProgressBar extends StatelessWidget {
       child: CustomPaint(
         painter: _ProgressBarPainter(
           value: value,
-          draggableValue: context.calcRelativePosition(
-            value.duration,
-            latestDraggableOffset,
-          ),
+          draggableValue: latestDraggableOffset != null
+              ? context.calcRelativePosition(
+                  value.duration,
+                  latestDraggableOffset!,
+                )
+              : null,
           colors: colors,
           barHeight: barHeight,
           handleHeight: handleHeight,
@@ -183,6 +184,9 @@ class _ProgressBarPainter extends CustomPainter {
   final double barHeight;
   final double handleHeight;
   final bool drawShadow;
+
+  /// The value of the draggable progress bar.
+  /// If null, the progress bar is not being dragged.
   final Duration? draggableValue;
 
   @override
@@ -259,11 +263,10 @@ class _ProgressBarPainter extends CustomPainter {
 }
 
 extension RelativePositionExtensions on BuildContext {
-  Duration? calcRelativePosition(
+  Duration calcRelativePosition(
     Duration videoDuration,
-    Offset? globalPosition,
+    Offset globalPosition,
   ) {
-    if (globalPosition == null) return null;
     final box = findRenderObject()! as RenderBox;
     final Offset tapPos = box.globalToLocal(globalPosition);
     final double relative = (tapPos.dx / box.size.width).clamp(0, 1);

--- a/lib/src/progress_bar.dart
+++ b/lib/src/progress_bar.dart
@@ -58,10 +58,11 @@ class _VideoProgressBarState extends State<VideoProgressBar> {
   }
 
   void _seekToRelativePosition(Offset globalPosition) {
-    controller.seekTo(context.calcRelativePosition(
+    final relativePosition = context.calcRelativePosition(
       controller.value.duration,
       globalPosition,
-    ));
+    );
+    controller.seekTo(relativePosition ?? Duration.zero);
   }
 
   @override
@@ -74,6 +75,7 @@ class _VideoProgressBarState extends State<VideoProgressBar> {
         barHeight: widget.barHeight,
         handleHeight: widget.handleHeight,
         drawShadow: widget.drawShadow,
+        latestDraggableOffset: _latestDraggableOffset,
       ),
     );
 
@@ -181,7 +183,7 @@ class _ProgressBarPainter extends CustomPainter {
   final double barHeight;
   final double handleHeight;
   final bool drawShadow;
-  final Duration draggableValue;
+  final Duration? draggableValue;
 
   @override
   bool shouldRepaint(CustomPainter painter) {
@@ -205,8 +207,8 @@ class _ProgressBarPainter extends CustomPainter {
     if (!value.isInitialized) {
       return;
     }
-    final double playedPartPercent = (draggableValue != Duration.zero
-            ? draggableValue.inMilliseconds
+    final double playedPartPercent = (draggableValue != null
+            ? draggableValue!.inMilliseconds
             : value.position.inMilliseconds) /
         value.duration.inMilliseconds;
     final double playedPart =
@@ -257,11 +259,11 @@ class _ProgressBarPainter extends CustomPainter {
 }
 
 extension RelativePositionExtensions on BuildContext {
-  Duration calcRelativePosition(
+  Duration? calcRelativePosition(
     Duration videoDuration,
     Offset? globalPosition,
   ) {
-    if (globalPosition == null) return Duration.zero;
+    if (globalPosition == null) return null;
     final box = findRenderObject()! as RenderBox;
     final Offset tapPos = box.globalToLocal(globalPosition);
     final double relative = tapPos.dx / box.size.width;


### PR DESCRIPTION
This PR fixes issue #789 and the following bugs that were uncovered as a result of fixing it:
- Due to using Duration.zero as an invalid value, the pointer's behavior at the left edge of the progress bar was unnatural. 
- The pointer was able to go beyond the confines of the progress bar.