### PR TITLE
[Web] fix exit full screen issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.7.5
+* 🛠️ [#810](https://github.com/fluttercommunity/chewie/pull/810): Fixed : Web full screen issue (#790 #688). Thanks [ToddZeil](https://github.com/ToddZeil).
+
 ## 1.7.4
 * 🛠️ [#774](https://github.com/fluttercommunity/chewie/pull/774): Fixed : Playback speed reset on forwarding video. Thanks [Kronos-2701](https://github.com/Kronos-2701).
 

--- a/lib/src/chewie_player.dart
+++ b/lib/src/chewie_player.dart
@@ -6,6 +6,7 @@ import 'package:chewie/src/models/options_translation.dart';
 import 'package:chewie/src/models/subtitle_model.dart';
 import 'package:chewie/src/notifiers/player_notifier.dart';
 import 'package:chewie/src/player_with_controls.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
@@ -166,6 +167,18 @@ class ChewieState extends State<Chewie> {
       context,
       rootNavigator: widget.controller.useRootNavigator,
     ).push(route);
+
+    if (kIsWeb) {
+      final prevPosition =
+          widget.controller.videoPlayerController.value.position;
+      widget.controller.videoPlayerController.initialize().then((_) async {
+        widget.controller._initialize();
+        widget.controller.videoPlayerController.seekTo(prevPosition);
+        await widget.controller.videoPlayerController.play();
+        widget.controller.videoPlayerController.pause();
+      });
+    }
+
     _isFullScreen = false;
     widget.controller.exitFullScreen();
 

--- a/lib/src/chewie_player.dart
+++ b/lib/src/chewie_player.dart
@@ -169,14 +169,7 @@ class ChewieState extends State<Chewie> {
     ).push(route);
 
     if (kIsWeb) {
-      final prevPosition =
-          widget.controller.videoPlayerController.value.position;
-      widget.controller.videoPlayerController.initialize().then((_) async {
-        widget.controller._initialize();
-        widget.controller.videoPlayerController.seekTo(prevPosition);
-        await widget.controller.videoPlayerController.play();
-        widget.controller.videoPlayerController.pause();
-      });
+      _reInitializeControllers();
     }
 
     _isFullScreen = false;
@@ -244,6 +237,18 @@ class ChewieState extends State<Chewie> {
         SystemChrome.setPreferredOrientations(DeviceOrientation.values);
       }
     }
+  }
+
+  ///When viewing full screen on web, returning from full screen causes original video to lose the picture.
+  ///We re initialise controllers for web only when returning from full screen
+  void _reInitializeControllers() {
+    final prevPosition = widget.controller.videoPlayerController.value.position;
+    widget.controller.videoPlayerController.initialize().then((_) async {
+      widget.controller._initialize();
+      widget.controller.videoPlayerController.seekTo(prevPosition);
+      await widget.controller.videoPlayerController.play();
+      widget.controller.videoPlayerController.pause();
+    });
   }
 }
 

--- a/lib/src/material/material_desktop_controls.dart
+++ b/lib/src/material/material_desktop_controls.dart
@@ -485,40 +485,37 @@ class _MaterialDesktopControlsState extends State<MaterialDesktopControls>
   void _onExpandCollapse() {
     setState(() {
       notifier.hideStuff = true;
+    });
 
-      chewieController.toggleFullScreen();
-      _showAfterExpandCollapseTimer =
-          Timer(const Duration(milliseconds: 300), () {
-        setState(() {
-          _cancelAndRestartTimer();
-        });
+    chewieController.toggleFullScreen();
+
+    _showAfterExpandCollapseTimer =
+        Timer(const Duration(milliseconds: 300), () {
+      setState(() {
+        _cancelAndRestartTimer();
       });
     });
   }
 
   void _playPause() {
-    final isFinished = _latestValue.position >= _latestValue.duration;
-
-    setState(() {
-      if (controller.value.isPlaying) {
+    if (controller.value.isPlaying) {
+      setState(() {
         notifier.hideStuff = false;
-        _hideTimer?.cancel();
-        controller.pause();
-      } else {
-        _cancelAndRestartTimer();
+      });
 
-        if (!controller.value.isInitialized) {
-          controller.initialize().then((_) {
-            controller.play();
-          });
-        } else {
-          if (isFinished) {
-            controller.seekTo(Duration.zero);
-          }
+      _hideTimer?.cancel();
+      controller.pause();
+    } else {
+      _cancelAndRestartTimer();
+
+      if (!controller.value.isInitialized) {
+        controller.initialize().then((_) {
           controller.play();
-        }
+        });
+      } else {
+        controller.play();
       }
-    });
+    }
   }
 
   void _startHideTimer() {

--- a/lib/src/material/material_desktop_controls.dart
+++ b/lib/src/material/material_desktop_controls.dart
@@ -510,9 +510,11 @@ class _MaterialDesktopControlsState extends State<MaterialDesktopControls>
 
       if (!controller.value.isInitialized) {
         controller.initialize().then((_) {
+          //[VideoPlayerController.play] If the video is at the end, this method starts playing from the beginning
           controller.play();
         });
       } else {
+        //[VideoPlayerController.play] If the video is at the end, this method starts playing from the beginning
         controller.play();
       }
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: chewie
 description: A video player for Flutter with Cupertino and Material play controls
-version: 1.7.4
+version: 1.7.5
 homepage: http://github.com/fluttercommunity/chewie
 
 environment:


### PR DESCRIPTION
https://github.com/fluttercommunity/chewie/issues/790
https://github.com/fluttercommunity/chewie/issues/688

When viewing full screen on web, returning from full screen causes original video to lose picture.
We re initialise controllers for web only when returning from full screen 

Also refactor un needed set states, refactor play if finished( as video player restarts if finished)