### PR TITLE
Refactor VideoPlayerController initialization to adhere to video_player ^2.8.2 guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ dependencies:
 
 ```dart
 import 'package:chewie/chewie.dart';
-final videoPlayerController = VideoPlayerController.network(
-    'https://flutter.github.io/assets-for-api-docs/assets/videos/butterfly.mp4');
+final videoPlayerController = VideoPlayerController.networkUrl(Uri.parse(
+    'https://flutter.github.io/assets-for-api-docs/assets/videos/butterfly.mp4'));
 
 await videoPlayerController.initialize();
 


### PR DESCRIPTION
Updated VideoPlayerController initialization to use VideoPlayerController.networkUrl(Uri.parse('video_url')), complying with video_player ^2.8.2 guidelines.

Changes :
```dart
final videoPlayerController = VideoPlayerController.network(
    'https://flutter.github.io/assets-for-api-docs/assets/videos/butterfly.mp4'); 
   
   To 
   
   final videoPlayerController = VideoPlayerController.networkUrl(Uri.parse(
    'https://flutter.github.io/assets-for-api-docs/assets/videos/butterfly.mp4'));
   
   