### PR TITLE
Fix the Safe area conflict for material controls in Android

### DIFF
--- a/lib/src/material/material_controls.dart
+++ b/lib/src/material/material_controls.dart
@@ -261,6 +261,7 @@ class _MaterialControlsState extends State<MaterialControls>
           bottom: !chewieController.isFullScreen ? 10.0 : 0,
         ),
         child: SafeArea(
+          top: false,
           bottom: chewieController.isFullScreen,
           minimum: chewieController.controlsSafeAreaMinimum,
           child: Column(


### PR DESCRIPTION
### The issue:

When a player widget is used inside a scaffold with `extendBodyBehindAppBar` set to **true** on a _Scaffold_, the progress bar and the fullscreen button go out of the player bounds which breaks the layout and makes them inaccessible for a user's input.

## Example from real app:
`extendBodyBehindAppBar: true`, controls are falling down
<img src="https://github.com/fluttercommunity/chewie/assets/25031713/eecc262a-0035-4e30-9187-609fe2b7aa22" width="200">

`extendBodyBehindAppBar: false`, controls are fine, but we need the content of the screen go under the app bar
<img src="https://github.com/fluttercommunity/chewie/assets/25031713/6889db3b-46b3-44c4-8ff8-085eabfbd819" width="200">

`extendBodyBehindAppBar: true`, and the fix from PR
This is how it should work. 
<img src="https://github.com/fluttercommunity/chewie/assets/25031713/73192e55-f784-489e-9382-d330fc01dfc9" width="200">

If I got it right the issue is Android/Fucsia related, since MaterialControls do not used for others. This was not tested on Fucsia.