### PR TITLE
Flutter 3.19 enforcement

### DIFF
--- a/example/lib/app/app.dart
+++ b/example/lib/app/app.dart
@@ -3,14 +3,13 @@ import 'dart:io';
 import 'package:chewie/chewie.dart';
 import 'package:chewie_example/app/theme.dart';
 import 'package:flutter/material.dart';
-// ignore: depend_on_referenced_packages
 import 'package:video_player/video_player.dart';
 
 class ChewieDemo extends StatefulWidget {
   const ChewieDemo({
-    Key? key,
+    super.key,
     this.title = 'Chewie Demo',
-  }) : super(key: key);
+  });
 
   final String title;
 
@@ -333,8 +332,7 @@ class _ChewieDemoState extends State<ChewieDemo> {
 }
 
 class DelaySlider extends StatefulWidget {
-  const DelaySlider({Key? key, required this.delay, required this.onSave})
-      : super(key: key);
+  const DelaySlider({super.key, required this.delay, required this.onSave});
 
   final int? delay;
   final void Function(int?) onSave;

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -4,8 +4,8 @@ version: 1.0.0
 publish_to: none
 
 environment:
-  sdk: '>=2.18.0 <4.0.0'
-  flutter: ">=3.10.0"
+  sdk: '>=3.3.0 <4.0.0'
+  flutter: ">=3.19.0"
 
 dependencies:
   chewie:
@@ -13,10 +13,11 @@ dependencies:
   flutter:
     sdk: flutter
 
+  video_player: any
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^2.0.1
+  flutter_lints: ^3.0.2
 
 # For information on the generic Dart part of this file, see the
 # following page: https://www.dartlang.org/tools/pub/pubspec

--- a/lib/src/animated_play_pause.dart
+++ b/lib/src/animated_play_pause.dart
@@ -3,11 +3,11 @@ import 'package:flutter/material.dart';
 /// A widget that animates implicitly between a play and a pause icon.
 class AnimatedPlayPause extends StatefulWidget {
   const AnimatedPlayPause({
-    Key? key,
+    super.key,
     required this.playing,
     this.size,
     this.color,
-  }) : super(key: key);
+  });
 
   final double? size;
   final bool playing;

--- a/lib/src/center_play_button.dart
+++ b/lib/src/center_play_button.dart
@@ -3,14 +3,14 @@ import 'package:flutter/material.dart';
 
 class CenterPlayButton extends StatelessWidget {
   const CenterPlayButton({
-    Key? key,
+    super.key,
     required this.backgroundColor,
     this.iconColor,
     required this.show,
     required this.isPlaying,
     required this.isFinished,
     this.onPressed,
-  }) : super(key: key);
+  });
 
   final Color backgroundColor;
   final Color? iconColor;

--- a/lib/src/chewie_player.dart
+++ b/lib/src/chewie_player.dart
@@ -26,9 +26,9 @@ typedef ChewieRoutePageBuilder = Widget Function(
 /// make it easy to use!
 class Chewie extends StatefulWidget {
   const Chewie({
-    Key? key,
+    super.key,
     required this.controller,
-  }) : super(key: key);
+  });
 
   /// The [ChewieController]
   final ChewieController controller;
@@ -647,10 +647,10 @@ class ChewieController extends ChangeNotifier {
 
 class ChewieControllerProvider extends InheritedWidget {
   const ChewieControllerProvider({
-    Key? key,
+    super.key,
     required this.controller,
-    required Widget child,
-  }) : super(key: key, child: child);
+    required super.child,
+  });
 
   final ChewieController controller;
 

--- a/lib/src/cupertino/cupertino_controls.dart
+++ b/lib/src/cupertino/cupertino_controls.dart
@@ -22,8 +22,8 @@ class CupertinoControls extends StatefulWidget {
     required this.backgroundColor,
     required this.iconColor,
     this.showPlayButton = true,
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   final Color backgroundColor;
   final Color iconColor;
@@ -822,12 +822,10 @@ class _CupertinoControlsState extends State<CupertinoControls>
 
 class _PlaybackSpeedDialog extends StatelessWidget {
   const _PlaybackSpeedDialog({
-    Key? key,
     required List<double> speeds,
     required double selected,
   })  : _speeds = speeds,
-        _selected = selected,
-        super(key: key);
+        _selected = selected;
 
   final List<double> _speeds;
   final double _selected;

--- a/lib/src/cupertino/cupertino_progress_bar.dart
+++ b/lib/src/cupertino/cupertino_progress_bar.dart
@@ -11,9 +11,8 @@ class CupertinoVideoProgressBar extends StatelessWidget {
     this.onDragEnd,
     this.onDragStart,
     this.onDragUpdate,
-    Key? key,
-  })  : colors = colors ?? ChewieProgressColors(),
-        super(key: key);
+    super.key,
+  })  : colors = colors ?? ChewieProgressColors();
 
   final VideoPlayerController controller;
   final ChewieProgressColors colors;

--- a/lib/src/cupertino/cupertino_progress_bar.dart
+++ b/lib/src/cupertino/cupertino_progress_bar.dart
@@ -12,7 +12,7 @@ class CupertinoVideoProgressBar extends StatelessWidget {
     this.onDragStart,
     this.onDragUpdate,
     super.key,
-  })  : colors = colors ?? ChewieProgressColors();
+  }) : colors = colors ?? ChewieProgressColors();
 
   final VideoPlayerController controller;
   final ChewieProgressColors colors;

--- a/lib/src/cupertino/widgets/cupertino_options_dialog.dart
+++ b/lib/src/cupertino/widgets/cupertino_options_dialog.dart
@@ -3,10 +3,10 @@ import 'package:flutter/cupertino.dart';
 
 class CupertinoOptionsDialog extends StatefulWidget {
   const CupertinoOptionsDialog({
-    Key? key,
+    super.key,
     required this.options,
     this.cancelButtonText,
-  }) : super(key: key);
+  });
 
   final List<OptionItem> options;
   final String? cancelButtonText;

--- a/lib/src/helpers/adaptive_controls.dart
+++ b/lib/src/helpers/adaptive_controls.dart
@@ -3,8 +3,8 @@ import 'package:flutter/material.dart';
 
 class AdaptiveControls extends StatelessWidget {
   const AdaptiveControls({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/material/material_controls.dart
+++ b/lib/src/material/material_controls.dart
@@ -17,8 +17,8 @@ import 'package:video_player/video_player.dart';
 class MaterialControls extends StatefulWidget {
   const MaterialControls({
     this.showPlayButton = true,
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   final bool showPlayButton;
 

--- a/lib/src/material/material_desktop_controls.dart
+++ b/lib/src/material/material_desktop_controls.dart
@@ -18,8 +18,8 @@ import 'package:video_player/video_player.dart';
 class MaterialDesktopControls extends StatefulWidget {
   const MaterialDesktopControls({
     this.showPlayButton = true,
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   final bool showPlayButton;
 

--- a/lib/src/material/material_progress_bar.dart
+++ b/lib/src/material/material_progress_bar.dart
@@ -11,9 +11,8 @@ class MaterialVideoProgressBar extends StatelessWidget {
     this.onDragEnd,
     this.onDragStart,
     this.onDragUpdate,
-    Key? key,
-  })  : colors = colors ?? ChewieProgressColors(),
-        super(key: key);
+    super.key,
+  })  : colors = colors ?? ChewieProgressColors();
 
   final double height;
   final VideoPlayerController controller;

--- a/lib/src/material/material_progress_bar.dart
+++ b/lib/src/material/material_progress_bar.dart
@@ -12,7 +12,7 @@ class MaterialVideoProgressBar extends StatelessWidget {
     this.onDragStart,
     this.onDragUpdate,
     super.key,
-  })  : colors = colors ?? ChewieProgressColors();
+  }) : colors = colors ?? ChewieProgressColors();
 
   final double height;
   final VideoPlayerController controller;

--- a/lib/src/material/widgets/options_dialog.dart
+++ b/lib/src/material/widgets/options_dialog.dart
@@ -3,10 +3,10 @@ import 'package:flutter/material.dart';
 
 class OptionsDialog extends StatefulWidget {
   const OptionsDialog({
-    Key? key,
+    super.key,
     required this.options,
     this.cancelButtonText,
-  }) : super(key: key);
+  });
 
   final List<OptionItem> options;
   final String? cancelButtonText;

--- a/lib/src/material/widgets/playback_speed_dialog.dart
+++ b/lib/src/material/widgets/playback_speed_dialog.dart
@@ -2,12 +2,11 @@ import 'package:flutter/material.dart';
 
 class PlaybackSpeedDialog extends StatelessWidget {
   const PlaybackSpeedDialog({
-    Key? key,
+    super.key,
     required List<double> speeds,
     required double selected,
   })  : _speeds = speeds,
-        _selected = selected,
-        super(key: key);
+        _selected = selected;
 
   final List<double> _speeds;
   final double _selected;

--- a/lib/src/player_with_controls.dart
+++ b/lib/src/player_with_controls.dart
@@ -6,7 +6,7 @@ import 'package:provider/provider.dart';
 import 'package:video_player/video_player.dart';
 
 class PlayerWithControls extends StatelessWidget {
-  const PlayerWithControls({Key? key}) : super(key: key);
+  const PlayerWithControls({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/progress_bar.dart
+++ b/lib/src/progress_bar.dart
@@ -13,7 +13,7 @@ class VideoProgressBar extends StatefulWidget {
     required this.barHeight,
     required this.handleHeight,
     required this.drawShadow,
-  })  : colors = colors ?? ChewieProgressColors();
+  }) : colors = colors ?? ChewieProgressColors();
 
   final VideoPlayerController controller;
   final ChewieProgressColors colors;

--- a/lib/src/progress_bar.dart
+++ b/lib/src/progress_bar.dart
@@ -9,12 +9,11 @@ class VideoProgressBar extends StatefulWidget {
     this.onDragEnd,
     this.onDragStart,
     this.onDragUpdate,
-    Key? key,
+    super.key,
     required this.barHeight,
     required this.handleHeight,
     required this.drawShadow,
-  })  : colors = colors ?? ChewieProgressColors(),
-        super(key: key);
+  })  : colors = colors ?? ChewieProgressColors();
 
   final VideoPlayerController controller;
   final ChewieProgressColors colors;
@@ -126,14 +125,14 @@ class _VideoProgressBarState extends State<VideoProgressBar> {
 
 class StaticProgressBar extends StatelessWidget {
   const StaticProgressBar({
-    Key? key,
+    super.key,
     required this.value,
     required this.colors,
     required this.barHeight,
     required this.handleHeight,
     required this.drawShadow,
     this.latestDraggableOffset,
-  }) : super(key: key);
+  });
 
   final Offset? latestDraggableOffset;
   final VideoPlayerValue value;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: chewie
 description: A video player for Flutter with Cupertino and Material play controls
 version: 1.7.5
-homepage: http://github.com/fluttercommunity/chewie
+homepage: https://github.com/fluttercommunity/chewie
 
 environment:
-  sdk: '>=2.18.0 <4.0.0'
-  flutter: ">=3.3.0"
+  sdk: '>=3.3.0 <4.0.0'
+  flutter: ">=3.19.0"
 
 dependencies:
   cupertino_icons: ^1.0.5
@@ -18,7 +18,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^2.0.2
+  flutter_lints: ^3.0.2
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
Due to `wakelock_plus` version `1.2.x`, the next minor release will require Flutter `3.19` and Dart `3.3` or higher.