### PR TITLE
Add barHeight and handleHeight for MaterialVideoProgressBar

### DIFF
--- a/lib/chewie.dart
+++ b/lib/chewie.dart
@@ -4,5 +4,6 @@ export 'src/chewie_player.dart';
 export 'src/chewie_progress_colors.dart';
 export 'src/cupertino/cupertino_controls.dart';
 export 'src/material/material_controls.dart';
+export 'src/material/material_progress_bar.dart';
 export 'src/material/material_desktop_controls.dart';
 export 'src/models/index.dart';

--- a/lib/src/cupertino/cupertino_controls.dart
+++ b/lib/src/cupertino/cupertino_controls.dart
@@ -720,6 +720,7 @@ class _CupertinoControlsState extends State<CupertinoControls>
                   255,
                 ),
               ),
+          draggableProgressBar: chewieController.draggableProgressBar,
         ),
       ),
     );

--- a/lib/src/cupertino/cupertino_progress_bar.dart
+++ b/lib/src/cupertino/cupertino_progress_bar.dart
@@ -12,6 +12,7 @@ class CupertinoVideoProgressBar extends StatelessWidget {
     this.onDragStart,
     this.onDragUpdate,
     super.key,
+    this.draggableProgressBar = true,
   }) : colors = colors ?? ChewieProgressColors();
 
   final VideoPlayerController controller;
@@ -19,6 +20,7 @@ class CupertinoVideoProgressBar extends StatelessWidget {
   final Function()? onDragStart;
   final Function()? onDragEnd;
   final Function()? onDragUpdate;
+  final bool draggableProgressBar;
 
   @override
   Widget build(BuildContext context) {
@@ -31,6 +33,7 @@ class CupertinoVideoProgressBar extends StatelessWidget {
       onDragEnd: onDragEnd,
       onDragStart: onDragStart,
       onDragUpdate: onDragUpdate,
+      draggableProgressBar: draggableProgressBar,
     );
   }
 }

--- a/lib/src/material/material_controls.dart
+++ b/lib/src/material/material_controls.dart
@@ -615,6 +615,7 @@ class _MaterialControlsState extends State<MaterialControls>
                   Theme.of(context).colorScheme.background.withOpacity(0.5),
               backgroundColor: Theme.of(context).disabledColor.withOpacity(.5),
             ),
+        draggableProgressBar: chewieController.draggableProgressBar,
       ),
     );
   }

--- a/lib/src/material/material_desktop_controls.dart
+++ b/lib/src/material/material_desktop_controls.dart
@@ -592,6 +592,7 @@ class _MaterialDesktopControlsState extends State<MaterialDesktopControls>
                   Theme.of(context).colorScheme.background.withOpacity(0.5),
               backgroundColor: Theme.of(context).disabledColor.withOpacity(.5),
             ),
+        draggableProgressBar: chewieController.draggableProgressBar,
       ),
     );
   }

--- a/lib/src/material/material_progress_bar.dart
+++ b/lib/src/material/material_progress_bar.dart
@@ -14,6 +14,7 @@ class MaterialVideoProgressBar extends StatelessWidget {
     this.onDragStart,
     this.onDragUpdate,
     super.key,
+    this.draggableProgressBar = true,
   }) : colors = colors ?? ChewieProgressColors();
 
   final double height;
@@ -24,6 +25,7 @@ class MaterialVideoProgressBar extends StatelessWidget {
   final Function()? onDragStart;
   final Function()? onDragEnd;
   final Function()? onDragUpdate;
+  final bool draggableProgressBar;
 
   @override
   Widget build(BuildContext context) {
@@ -36,6 +38,7 @@ class MaterialVideoProgressBar extends StatelessWidget {
       onDragEnd: onDragEnd,
       onDragStart: onDragStart,
       onDragUpdate: onDragUpdate,
+      draggableProgressBar: draggableProgressBar,
     );
   }
 }

--- a/lib/src/material/material_progress_bar.dart
+++ b/lib/src/material/material_progress_bar.dart
@@ -7,6 +7,8 @@ class MaterialVideoProgressBar extends StatelessWidget {
   MaterialVideoProgressBar(
     this.controller, {
     this.height = kToolbarHeight,
+    this.barHeight = 10,
+    this.handleHeight = 6,
     ChewieProgressColors? colors,
     this.onDragEnd,
     this.onDragStart,
@@ -15,6 +17,8 @@ class MaterialVideoProgressBar extends StatelessWidget {
   }) : colors = colors ?? ChewieProgressColors();
 
   final double height;
+  final double barHeight;
+  final double handleHeight;
   final VideoPlayerController controller;
   final ChewieProgressColors colors;
   final Function()? onDragStart;
@@ -25,8 +29,8 @@ class MaterialVideoProgressBar extends StatelessWidget {
   Widget build(BuildContext context) {
     return VideoProgressBar(
       controller,
-      barHeight: 10,
-      handleHeight: 6,
+      barHeight: barHeight,
+      handleHeight: handleHeight,
       drawShadow: true,
       colors: colors,
       onDragEnd: onDragEnd,

--- a/lib/src/progress_bar.dart
+++ b/lib/src/progress_bar.dart
@@ -9,6 +9,7 @@ class VideoProgressBar extends StatefulWidget {
     this.onDragEnd,
     this.onDragStart,
     this.onDragUpdate,
+    this.draggableProgressBar = true,
     super.key,
     required this.barHeight,
     required this.handleHeight,
@@ -24,6 +25,7 @@ class VideoProgressBar extends StatefulWidget {
   final double barHeight;
   final double handleHeight;
   final bool drawShadow;
+  final bool draggableProgressBar;
 
   @override
   // ignore: library_private_types_in_public_api
@@ -65,7 +67,6 @@ class _VideoProgressBarState extends State<VideoProgressBar> {
 
   @override
   Widget build(BuildContext context) {
-    final ChewieController chewieController = ChewieController.of(context);
     final child = Center(
       child: StaticProgressBar(
         value: controller.value,
@@ -77,7 +78,7 @@ class _VideoProgressBarState extends State<VideoProgressBar> {
       ),
     );
 
-    return chewieController.draggableProgressBar
+    return widget.draggableProgressBar
         ? GestureDetector(
             onHorizontalDragStart: (DragStartDetails details) {
               if (!controller.value.isInitialized) {


### PR DESCRIPTION
### Changes being made

1. Export MaterialVideoProgressBar widget for ChewieController's customControls usage to achieve below ui.
<img width="318" alt="image" src="https://github.com/fluttercommunity/chewie/assets/56582497/0f6ccd48-36db-411c-933e-0490cc0dc20a">

2. Add barHeight and handleHeight properties in MaterialVideoProgressBar widget for height customization.