### PR TITLE
Hide options without play stop button

### DIFF
--- a/lib/src/material/material_controls.dart
+++ b/lib/src/material/material_controls.dart
@@ -92,7 +92,7 @@ class _MaterialControlsState extends State<MaterialControls>
                 )
               else
                 _buildHitArea(),
-              if (hideControlsWithoutPlayButton == false) ...[
+              if (widget.hideControlsWithoutPlayButton == false) ...[
                 _buildActionBar(),
                 Column(
                   mainAxisAlignment: MainAxisAlignment.end,

--- a/lib/src/material/material_controls.dart
+++ b/lib/src/material/material_controls.dart
@@ -17,10 +17,12 @@ import 'package:video_player/video_player.dart';
 class MaterialControls extends StatefulWidget {
   const MaterialControls({
     this.showPlayButton = true,
+    this.hideControlsWithoutPlayButton = false,
     super.key,
   });
 
   final bool showPlayButton;
+  final bool hideControlsWithoutPlayButton;
 
   @override
   State<StatefulWidget> createState() {
@@ -90,22 +92,24 @@ class _MaterialControlsState extends State<MaterialControls>
                 )
               else
                 _buildHitArea(),
-              _buildActionBar(),
-              Column(
-                mainAxisAlignment: MainAxisAlignment.end,
-                children: <Widget>[
-                  if (_subtitleOn)
-                    Transform.translate(
-                      offset: Offset(
-                        0.0,
-                        notifier.hideStuff ? barHeight * 0.8 : 0.0,
-                      ),
-                      child:
+              if (hideControlsWithoutPlayButton == false) ...[
+                _buildActionBar(),
+                Column(
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  children: <Widget>[
+                    if (_subtitleOn)
+                      Transform.translate(
+                        offset: Offset(
+                          0.0,
+                          notifier.hideStuff ? barHeight * 0.8 : 0.0,
+                        ),
+                        child:
                           _buildSubtitles(context, chewieController.subtitle!),
-                    ),
-                  _buildBottomBar(context),
-                ],
-              ),
+                      ),
+                      _buildBottomBar(context),
+                  ],
+                ),
+              ],
             ],
           ),
         ),


### PR DESCRIPTION
This feature based on specific usage of MaterialControls from Chewie, appends hideControlsWithoutPlayButton option to MaterialControls for hide controls without play/pause button of player.