### PR TITLE
Fixed pop the wrong page when changing the speed and added support for multiple resolutions

### DIFF
--- a/example/lib/app/app.dart
+++ b/example/lib/app/app.dart
@@ -41,9 +41,10 @@ class _ChewieDemoState extends State<ChewieDemo> {
   }
 
   List<String> srcs = [
-    "https://assets.mixkit.co/videos/preview/mixkit-spinning-around-the-earth-29351-large.mp4",
-    "https://assets.mixkit.co/videos/preview/mixkit-daytime-city-traffic-aerial-view-56-large.mp4",
-    "https://assets.mixkit.co/videos/preview/mixkit-a-girl-blowing-a-bubble-gum-at-an-amusement-park-1226-large.mp4"
+    "https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ElephantsDream.mp4",
+    // "https://assets.mixkit.co/videos/preview/mixkit-spinning-around-the-earth-29351-large.mp4",
+    // "https://assets.mixkit.co/videos/preview/mixkit-daytime-city-traffic-aerial-view-56-large.mp4",
+    // "https://assets.mixkit.co/videos/preview/mixkit-a-girl-blowing-a-bubble-gum-at-an-amusement-park-1226-large.mp4"
   ];
 
   Future<void> initializePlayer() async {
@@ -153,6 +154,19 @@ class _ChewieDemoState extends State<ChewieDemo> {
       //   color: Colors.grey,
       // ),
       // autoInitialize: true,
+      allowQualityChanging: true,
+      qualities: {
+        '240p':
+            'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ElephantsDream.mp4',
+        '360p':
+            'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ElephantsDream.mp4',
+        '540p':
+            'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ElephantsDream.mp4',
+        '720p':
+            'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ElephantsDream.mp4',
+        '1080p':
+            'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ElephantsDream.mp4',
+      },
     );
   }
 

--- a/lib/src/cupertino/cupertino_controls.dart
+++ b/lib/src/cupertino/cupertino_controls.dart
@@ -145,11 +145,13 @@ class _CupertinoControlsState extends State<CupertinoControls> with SingleTicker
     final oldController = _chewieController;
     _chewieController = ChewieController.of(context);
     _chewieController?.addListener(() {
-      setState(() {
-        controller = chewieController.videoPlayerController;
+      if (mounted) {
+        setState(() {
+          controller = chewieController.videoPlayerController;
+        });
         _dispose();
         _initialize();
-      });
+      }
     });
     controller = chewieController.videoPlayerController;
 

--- a/lib/src/cupertino/cupertino_controls.dart
+++ b/lib/src/cupertino/cupertino_controls.dart
@@ -163,10 +163,7 @@ class _CupertinoControlsState extends State<CupertinoControls> with SingleTicker
     super.didChangeDependencies();
   }
 
-  GestureDetector _buildOptionsButton(
-    Color iconColor,
-    double barHeight,
-  ) {
+  List<OptionItem> _buildOptions(BuildContext context) {
     final options = <OptionItem>[];
 
     if (chewieController.allowQualityChanging) {
@@ -187,19 +184,26 @@ class _CupertinoControlsState extends State<CupertinoControls> with SingleTicker
       options.addAll(chewieController.additionalOptions!(context));
     }
 
+    return options;
+  }
+
+  GestureDetector _buildOptionsButton(
+    Color iconColor,
+    double barHeight,
+  ) {
     return GestureDetector(
       onTap: () async {
         _hideTimer?.cancel();
 
         if (chewieController.optionsBuilder != null) {
-          await chewieController.optionsBuilder!(context, options);
+          await chewieController.optionsBuilder!(context, _buildOptions(context));
         } else {
           await showCupertinoModalPopup<OptionItem>(
             context: context,
             semanticsDismissible: true,
             useRootNavigator: chewieController.useRootNavigator,
             builder: (context) => CupertinoOptionsDialog(
-              options: options,
+              options: _buildOptions(context),
               cancelButtonText: chewieController.optionsTranslation?.cancelButtonText,
             ),
           );
@@ -305,7 +309,8 @@ class _CupertinoControlsState extends State<CupertinoControls> with SingleTicker
                           if (chewieController.allowPlaybackSpeedChanging)
                             _buildSpeedButton(controller, iconColor, barHeight),
                           if (chewieController.additionalOptions != null &&
-                              chewieController.additionalOptions!(context).isNotEmpty)
+                                  chewieController.additionalOptions!(context).isNotEmpty ||
+                              chewieController.allowQualityChanging)
                             _buildOptionsButton(iconColor, barHeight),
                         ],
                       ),
@@ -652,14 +657,14 @@ class _CupertinoControlsState extends State<CupertinoControls> with SingleTicker
     _hideTimer?.cancel();
 
     final chosenQuality = await showCupertinoModalPopup<String>(
-          context: context,
-          semanticsDismissible: true,
-          useRootNavigator: chewieController.useRootNavigator,
-          builder: (context) => _QualityDialog(
-            qualities: chewieController.qualities.keys.toList(),
-            selected: chewieController.quality,
-          ),
-        );
+      context: context,
+      semanticsDismissible: true,
+      useRootNavigator: chewieController.useRootNavigator,
+      builder: (context) => _QualityDialog(
+        qualities: chewieController.qualities.keys.toList(),
+        selected: chewieController.quality,
+      ),
+    );
 
     if (chosenQuality != null && chosenQuality != chewieController.quality) {
       _chewieController!.setQuality(chosenQuality);

--- a/lib/src/material/material_controls.dart
+++ b/lib/src/material/material_controls.dart
@@ -8,6 +8,7 @@ import 'package:chewie/src/helpers/utils.dart';
 import 'package:chewie/src/material/material_progress_bar.dart';
 import 'package:chewie/src/material/widgets/options_dialog.dart';
 import 'package:chewie/src/material/widgets/playback_speed_dialog.dart';
+import 'package:chewie/src/material/widgets/quality_dialog.dart';
 import 'package:chewie/src/models/option_item.dart';
 import 'package:chewie/src/models/subtitle_model.dart';
 import 'package:chewie/src/notifiers/index.dart';
@@ -132,6 +133,13 @@ class _MaterialControlsState extends State<MaterialControls>
   void didChangeDependencies() {
     final oldController = _chewieController;
     _chewieController = ChewieController.of(context);
+    _chewieController?.addListener(() {
+      setState(() {
+        controller = chewieController.videoPlayerController;
+        _dispose();
+        _initialize();
+      });
+    });
     controller = chewieController.videoPlayerController;
 
     if (oldController != chewieController) {
@@ -161,7 +169,7 @@ class _MaterialControlsState extends State<MaterialControls>
     );
   }
 
-  Widget _buildOptionsButton() {
+  List<OptionItem> _buildOptions(BuildContext context) {
     final options = <OptionItem>[
       OptionItem(
         onTap: () async {
@@ -169,16 +177,26 @@ class _MaterialControlsState extends State<MaterialControls>
           _onSpeedButtonTap();
         },
         iconData: Icons.speed,
-        title: chewieController.optionsTranslation?.playbackSpeedButtonText ??
-            'Playback speed',
-      )
+        title: chewieController.optionsTranslation?.playbackSpeedButtonText ?? 'Playback speed',
+      ),
+      if (chewieController.allowQualityChanging)
+        OptionItem(
+          onTap: () async {
+            Navigator.pop(context);
+            _onQualityButtonTap();
+          },
+          iconData: Icons.settings,
+          title: chewieController.optionsTranslation?.qualityButtonText ?? 'Quality',
+        ),
     ];
-
     if (chewieController.additionalOptions != null &&
         chewieController.additionalOptions!(context).isNotEmpty) {
       options.addAll(chewieController.additionalOptions!(context));
     }
+    return options;
+  }
 
+  Widget _buildOptionsButton() {
     return AnimatedOpacity(
       opacity: notifier.hideStuff ? 0.0 : 1.0,
       duration: const Duration(milliseconds: 250),
@@ -187,16 +205,15 @@ class _MaterialControlsState extends State<MaterialControls>
           _hideTimer?.cancel();
 
           if (chewieController.optionsBuilder != null) {
-            await chewieController.optionsBuilder!(context, options);
+            await chewieController.optionsBuilder!(context, _buildOptions(context));
           } else {
             await showModalBottomSheet<OptionItem>(
               context: context,
               isScrollControlled: true,
               useRootNavigator: chewieController.useRootNavigator,
               builder: (context) => OptionsDialog(
-                options: options,
-                cancelButtonText:
-                    chewieController.optionsTranslation?.cancelButtonText,
+                options: _buildOptions(context),
+                cancelButtonText: chewieController.optionsTranslation?.cancelButtonText,
               ),
             );
           }
@@ -450,6 +467,28 @@ class _MaterialControlsState extends State<MaterialControls>
 
     if (chosenSpeed != null) {
       controller.setPlaybackSpeed(chosenSpeed);
+    }
+
+    if (_latestValue.isPlaying) {
+      _startHideTimer();
+    }
+  }
+
+  Future<void> _onQualityButtonTap() async {
+    _hideTimer?.cancel();
+
+    final chosenQuality = await showModalBottomSheet<String>(
+      context: context,
+      isScrollControlled: true,
+      useRootNavigator: chewieController.useRootNavigator,
+      builder: (context) => QualityDialog(
+        qualities: chewieController.qualities.keys.toList(),
+        selected: chewieController.quality,
+      ),
+    );
+
+    if (chosenQuality != null && chosenQuality != chewieController.quality) {
+      _chewieController!.setQuality(chosenQuality);
     }
 
     if (_latestValue.isPlaying) {

--- a/lib/src/material/material_controls.dart
+++ b/lib/src/material/material_controls.dart
@@ -134,11 +134,13 @@ class _MaterialControlsState extends State<MaterialControls>
     final oldController = _chewieController;
     _chewieController = ChewieController.of(context);
     _chewieController?.addListener(() {
-      setState(() {
-        controller = chewieController.videoPlayerController;
+      if (mounted) {
+        setState(() {
+          controller = chewieController.videoPlayerController;
+        });
         _dispose();
         _initialize();
-      });
+      }
     });
     controller = chewieController.videoPlayerController;
 

--- a/lib/src/material/widgets/quality_dialog.dart
+++ b/lib/src/material/widgets/quality_dialog.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+
+class QualityDialog extends StatelessWidget {
+  const QualityDialog({
+    super.key,
+    required List<String> qualities,
+    required String selected,
+  })  : _qualities = qualities,
+        _selected = selected;
+
+  final List<String> _qualities;
+  final String _selected;
+
+  @override
+  Widget build(BuildContext context) {
+    final Color selectedColor = Theme.of(context).primaryColor;
+
+    return ListView.builder(
+      shrinkWrap: true,
+      physics: const ScrollPhysics(),
+      itemBuilder: (context, index) {
+        final quality = _qualities[index];
+        return ListTile(
+          dense: true,
+          title: Row(
+            children: [
+              if (quality == _selected)
+                Icon(
+                  Icons.check,
+                  size: 20.0,
+                  color: selectedColor,
+                )
+              else
+                Container(width: 20.0),
+              const SizedBox(width: 16.0),
+              Text(quality),
+            ],
+          ),
+          selected: quality == _selected,
+          onTap: () {
+            Navigator.of(context).pop(quality);
+          },
+        );
+      },
+      itemCount: _qualities.length,
+    );
+  }
+}

--- a/lib/src/models/options_translation.dart
+++ b/lib/src/models/options_translation.dart
@@ -3,28 +3,32 @@ class OptionsTranslation {
     this.playbackSpeedButtonText,
     this.subtitlesButtonText,
     this.cancelButtonText,
+    this.qualityButtonText,
   });
 
   String? playbackSpeedButtonText;
   String? subtitlesButtonText;
   String? cancelButtonText;
+  String? qualityButtonText;
 
   OptionsTranslation copyWith({
     String? playbackSpeedButtonText,
     String? subtitlesButtonText,
     String? cancelButtonText,
+    String? qualityButtonText,
   }) {
     return OptionsTranslation(
       playbackSpeedButtonText:
           playbackSpeedButtonText ?? this.playbackSpeedButtonText,
       subtitlesButtonText: subtitlesButtonText ?? this.subtitlesButtonText,
       cancelButtonText: cancelButtonText ?? this.cancelButtonText,
+      qualityButtonText: qualityButtonText ?? this.qualityButtonText,
     );
   }
 
   @override
   String toString() =>
-      'OptionsTranslation(playbackSpeedButtonText: $playbackSpeedButtonText, subtitlesButtonText: $subtitlesButtonText, cancelButtonText: $cancelButtonText)';
+      'OptionsTranslation(playbackSpeedButtonText: $playbackSpeedButtonText, subtitlesButtonText: $subtitlesButtonText, cancelButtonText: $cancelButtonText, qualityButtonText: $qualityButtonText)';
 
   @override
   bool operator ==(Object other) {
@@ -33,12 +37,14 @@ class OptionsTranslation {
     return other is OptionsTranslation &&
         other.playbackSpeedButtonText == playbackSpeedButtonText &&
         other.subtitlesButtonText == subtitlesButtonText &&
-        other.cancelButtonText == cancelButtonText;
+        other.cancelButtonText == cancelButtonText && 
+        other.qualityButtonText == qualityButtonText;
   }
 
   @override
   int get hashCode =>
       playbackSpeedButtonText.hashCode ^
       subtitlesButtonText.hashCode ^
-      cancelButtonText.hashCode;
+      cancelButtonText.hashCode ^ 
+      qualityButtonText.hashCode;
 }

--- a/lib/src/player_with_controls.dart
+++ b/lib/src/player_with_controls.dart
@@ -5,93 +5,107 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:video_player/video_player.dart';
 
-class PlayerWithControls extends StatelessWidget {
+class PlayerWithControls extends StatefulWidget {
   const PlayerWithControls({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    final ChewieController chewieController = ChewieController.of(context);
+  State<PlayerWithControls> createState() => _PlayerWithControlsState();
+}
 
-    double calculateAspectRatio(BuildContext context) {
-      final size = MediaQuery.of(context).size;
-      final width = size.width;
-      final height = size.height;
+class _PlayerWithControlsState extends State<PlayerWithControls> {
+  late final ChewieController _chewieController;
 
-      return width > height ? width / height : height / width;
-    }
+  @override
+  void didChangeDependencies() {
+    _chewieController = ChewieController.of(context)
+      ..addListener(() {
+        if (mounted) setState(() {});
+      });
 
-    Widget buildControls(
-      BuildContext context,
-      ChewieController chewieController,
-    ) {
-      return chewieController.showControls
-          ? chewieController.customControls ?? const AdaptiveControls()
-          : const SizedBox();
-    }
+    super.didChangeDependencies();
+  }
 
-    Widget buildPlayerWithControls(
-      ChewieController chewieController,
-      BuildContext context,
-    ) {
-      return Stack(
-        children: <Widget>[
+  double calculateAspectRatio(BuildContext context) {
+    final size = MediaQuery.of(context).size;
+    final width = size.width;
+    final height = size.height;
+
+    return width > height ? width / height : height / width;
+  }
+
+  Widget buildControls(
+    BuildContext context,
+    ChewieController chewieController,
+  ) {
+    return chewieController.showControls
+        ? chewieController.customControls ?? const AdaptiveControls()
+        : const SizedBox();
+  }
+
+  Widget buildPlayerWithControls(
+    ChewieController chewieController,
+    BuildContext context,
+  ) {
+    return Stack(
+      children: <Widget>[
           if (chewieController.placeholder != null)
             chewieController.placeholder!,
-          InteractiveViewer(
-            transformationController: chewieController.transformationController,
-            maxScale: chewieController.maxScale,
-            panEnabled: chewieController.zoomAndPan,
-            scaleEnabled: chewieController.zoomAndPan,
-            child: Center(
-              child: AspectRatio(
-                aspectRatio: chewieController.aspectRatio ??
-                    chewieController.videoPlayerController.value.aspectRatio,
-                child: VideoPlayer(chewieController.videoPlayerController),
-              ),
+        InteractiveViewer(
+          transformationController: chewieController.transformationController,
+          maxScale: chewieController.maxScale,
+          panEnabled: chewieController.zoomAndPan,
+          scaleEnabled: chewieController.zoomAndPan,
+          child: Center(
+            child: AspectRatio(
+              aspectRatio: chewieController.aspectRatio ??
+                  chewieController.videoPlayerController.value.aspectRatio,
+              child: VideoPlayer(chewieController.videoPlayerController),
             ),
           ),
-          if (chewieController.overlay != null) chewieController.overlay!,
-          if (Theme.of(context).platform != TargetPlatform.iOS)
-            Consumer<PlayerNotifier>(
-              builder: (
-                BuildContext context,
-                PlayerNotifier notifier,
-                Widget? widget,
-              ) =>
-                  Visibility(
-                visible: !notifier.hideStuff,
-                child: AnimatedOpacity(
-                  opacity: notifier.hideStuff ? 0.0 : 0.8,
-                  duration: const Duration(
-                    milliseconds: 250,
-                  ),
-                  child: const DecoratedBox(
-                    decoration: BoxDecoration(color: Colors.black54),
-                    child: SizedBox.expand(),
-                  ),
+        ),
+        if (chewieController.overlay != null) chewieController.overlay!,
+        if (Theme.of(context).platform != TargetPlatform.iOS)
+          Consumer<PlayerNotifier>(
+            builder: (
+              BuildContext context,
+              PlayerNotifier notifier,
+              Widget? widget,
+            ) =>
+                Visibility(
+              visible: !notifier.hideStuff,
+              child: AnimatedOpacity(
+                opacity: notifier.hideStuff ? 0.0 : 0.8,
+                duration: const Duration(
+                  milliseconds: 250,
+                ),
+                child: const DecoratedBox(
+                  decoration: BoxDecoration(color: Colors.black54),
+                  child: SizedBox.expand(),
                 ),
               ),
             ),
-          if (!chewieController.isFullScreen)
-            buildControls(context, chewieController)
-          else
-            SafeArea(
-              bottom: false,
-              child: buildControls(context, chewieController),
-            ),
-        ],
-      );
-    }
+          ),
+        if (!chewieController.isFullScreen)
+          buildControls(context, chewieController)
+        else
+          SafeArea(
+            bottom: false,
+            child: buildControls(context, chewieController),
+          ),
+      ],
+    );
+  }
 
-    return LayoutBuilder(
-        builder: (BuildContext context, BoxConstraints constraints) {
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(builder: (BuildContext context, BoxConstraints constraints) {
       return Center(
         child: SizedBox(
           height: constraints.maxHeight,
           width: constraints.maxWidth,
           child: AspectRatio(
             aspectRatio: calculateAspectRatio(context),
-            child: buildPlayerWithControls(chewieController, context),
+            child: buildPlayerWithControls(_chewieController, context),
           ),
         ),
       );


### PR DESCRIPTION
**1. Fixed pop the wrong page when changing the speed**
Issue: https://github.com/fluttercommunity/chewie/issues/618

**2. Added support for multiple resolutions**
Issue: https://github.com/fluttercommunity/chewie/issues/852

Now, to be able to change the video resolution, you need to pass the following parameters to the `ChewieController`:
1. `allowQualityChanging: true` 
2. Map ```
qualities: {
        '240p': '<your link to a 240p video>',
        '360p': '<your link to a 360p video>',
        '720p': <your link to a 720p video>',
        '1080p': '<your link to a 1080p video>',
      }
```. The _key_ can be any string that you want to display in the list of resolutions in the player. The _value_ should be link to the video of this resolution.

Also, in order to be able to change the video resolution, I need to redefine the `videoPlayerController` inside the `ChiewieController`. Therefore, the `onVideoControllerChange` callback has been added, which will allow you to get a new controller when it is replaced.

The quality change has been added for iOS and Android only.