### PR TITLE
Fixed pop the wrong page when changing the speed

### DIFF
--- a/example/lib/app/app.dart
+++ b/example/lib/app/app.dart
@@ -158,7 +158,7 @@ class _ChewieDemoState extends State<ChewieDemo> {
 
   int currPlayIndex = 0;
 
-  Future<void> toggleVideo() async {
+  Future<void> toggleVideo(BuildContext context) async {
     await _videoPlayerController1.pause();
     currPlayIndex += 1;
     if (currPlayIndex >= srcs.length) {
@@ -175,157 +175,157 @@ class _ChewieDemoState extends State<ChewieDemo> {
         platform: _platform ?? Theme.of(context).platform,
       ),
       home: Scaffold(
-        appBar: AppBar(
-          title: Text(widget.title),
-        ),
-        body: Column(
-          children: <Widget>[
-            Expanded(
-              child: Center(
-                child: _chewieController != null &&
-                        _chewieController!
-                            .videoPlayerController.value.isInitialized
-                    ? Chewie(
-                        controller: _chewieController!,
-                      )
-                    : const Column(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: [
-                          CircularProgressIndicator(),
-                          SizedBox(height: 20),
-                          Text('Loading'),
-                        ],
-                      ),
-              ),
-            ),
-            TextButton(
-              onPressed: () {
-                _chewieController?.enterFullScreen();
-              },
-              child: const Text('Fullscreen'),
-            ),
-            Row(
-              children: <Widget>[
-                Expanded(
-                  child: TextButton(
-                    onPressed: () {
-                      setState(() {
-                        _videoPlayerController1.pause();
-                        _videoPlayerController1.seekTo(Duration.zero);
-                        _createChewieController();
-                      });
-                    },
-                    child: const Padding(
-                      padding: EdgeInsets.symmetric(vertical: 16.0),
-                      child: Text("Landscape Video"),
-                    ),
-                  ),
-                ),
-                Expanded(
-                  child: TextButton(
-                    onPressed: () {
-                      setState(() {
-                        _videoPlayerController2.pause();
-                        _videoPlayerController2.seekTo(Duration.zero);
-                        _chewieController = _chewieController!.copyWith(
-                          videoPlayerController: _videoPlayerController2,
-                          autoPlay: true,
-                          looping: true,
-                          /* subtitle: Subtitles([
-                            Subtitle(
-                              index: 0,
-                              start: Duration.zero,
-                              end: const Duration(seconds: 10),
-                              text: 'Hello from subtitles',
-                            ),
-                            Subtitle(
-                              index: 0,
-                              start: const Duration(seconds: 10),
-                              end: const Duration(seconds: 20),
-                              text: 'Whats up? :)',
-                            ),
-                          ]),
-                          subtitleBuilder: (context, subtitle) => Container(
-                            padding: const EdgeInsets.all(10.0),
-                            child: Text(
-                              subtitle,
-                              style: const TextStyle(color: Colors.white),
-                            ),
-                          ), */
-                        );
-                      });
-                    },
-                    child: const Padding(
-                      padding: EdgeInsets.symmetric(vertical: 16.0),
-                      child: Text("Portrait Video"),
-                    ),
-                  ),
-                )
-              ],
-            ),
-            Row(
-              children: <Widget>[
-                Expanded(
-                  child: TextButton(
-                    onPressed: () {
-                      setState(() {
-                        _platform = TargetPlatform.android;
-                      });
-                    },
-                    child: const Padding(
-                      padding: EdgeInsets.symmetric(vertical: 16.0),
-                      child: Text("Android controls"),
-                    ),
-                  ),
-                ),
-                Expanded(
-                  child: TextButton(
-                    onPressed: () {
-                      setState(() {
-                        _platform = TargetPlatform.iOS;
-                      });
-                    },
-                    child: const Padding(
-                      padding: EdgeInsets.symmetric(vertical: 16.0),
-                      child: Text("iOS controls"),
-                    ),
-                  ),
-                )
-              ],
-            ),
-            Row(
-              children: <Widget>[
-                Expanded(
-                  child: TextButton(
-                    onPressed: () {
-                      setState(() {
-                        _platform = TargetPlatform.windows;
-                      });
-                    },
-                    child: const Padding(
-                      padding: EdgeInsets.symmetric(vertical: 16.0),
-                      child: Text("Desktop controls"),
-                    ),
-                  ),
-                ),
-              ],
-            ),
-            if (Platform.isAndroid)
-              ListTile(
-                title: const Text("Delay"),
-                subtitle: DelaySlider(
+                                appBar: AppBar(
+                                  title: Text(widget.title),
+                                ),
+                                body: Column(
+                                  children: <Widget>[
+                                    Expanded(
+                                      child: Center(
+                                        child: _chewieController != null &&
+                                                _chewieController!
+                                                    .videoPlayerController.value.isInitialized
+                                            ? Chewie(
+                                                controller: _chewieController!,
+                                              )
+                                            : const Column(
+                                                mainAxisAlignment: MainAxisAlignment.center,
+                                                children: [
+                                                  CircularProgressIndicator(),
+                                                  SizedBox(height: 20),
+                                                  Text('Loading'),
+                                                ],
+                                              ),
+                                      ),
+                                    ),
+                                    TextButton(
+                                      onPressed: () {
+                                        _chewieController?.enterFullScreen();
+                                      },
+                                      child: const Text('Fullscreen'),
+                                    ),
+                                    Row(
+                                      children: <Widget>[
+                                        Expanded(
+                                          child: TextButton(
+                                            onPressed: () {
+                                              setState(() {
+                                                _videoPlayerController1.pause();
+                                                _videoPlayerController1.seekTo(Duration.zero);
+                                                _createChewieController();
+                                              });
+                                            },
+                                            child: const Padding(
+                                              padding: EdgeInsets.symmetric(vertical: 16.0),
+                                              child: Text("Landscape Video"),
+                                            ),
+                                          ),
+                                        ),
+                                        Expanded(
+                                          child: TextButton(
+                                            onPressed: () {
+                                              setState(() {
+                                                _videoPlayerController2.pause();
+                                                _videoPlayerController2.seekTo(Duration.zero);
+                                                _chewieController = _chewieController!.copyWith(
+                                                  videoPlayerController: _videoPlayerController2,
+                                                  autoPlay: true,
+                                                  looping: true,
+                                                  /* subtitle: Subtitles([
+                                Subtitle(
+                                  index: 0,
+                                  start: Duration.zero,
+                                  end: const Duration(seconds: 10),
+                                  text: 'Hello from subtitles',
+                                ),
+                                Subtitle(
+                                  index: 0,
+                                  start: const Duration(seconds: 10),
+                                  end: const Duration(seconds: 20),
+                                  text: 'Whats up? :)',
+                                ),
+                              ]),
+                              subtitleBuilder: (context, subtitle) => Container(
+                                padding: const EdgeInsets.all(10.0),
+                                child: Text(
+                                  subtitle,
+                                  style: const TextStyle(color: Colors.white),
+                                ),
+                              ), */
+                                                );
+                                              });
+                                            },
+                                            child: const Padding(
+                                              padding: EdgeInsets.symmetric(vertical: 16.0),
+                                              child: Text("Portrait Video"),
+                                            ),
+                                          ),
+                                        )
+                                      ],
+                                    ),
+                                    Row(
+                                      children: <Widget>[
+                                        Expanded(
+                                          child: TextButton(
+                                            onPressed: () {
+                                              setState(() {
+                                                _platform = TargetPlatform.android;
+                                              });
+                                            },
+                                            child: const Padding(
+                                              padding: EdgeInsets.symmetric(vertical: 16.0),
+                                              child: Text("Android controls"),
+                                            ),
+                                          ),
+                                        ),
+                                        Expanded(
+                                          child: TextButton(
+                                            onPressed: () {
+                                              setState(() {
+                                                _platform = TargetPlatform.iOS;
+                                              });
+                                            },
+                                            child: const Padding(
+                                              padding: EdgeInsets.symmetric(vertical: 16.0),
+                                              child: Text("iOS controls"),
+                                            ),
+                                          ),
+                                        )
+                                      ],
+                                    ),
+                                    Row(
+                                      children: <Widget>[
+                                        Expanded(
+                                          child: TextButton(
+                                            onPressed: () {
+                                              setState(() {
+                                                _platform = TargetPlatform.windows;
+                                              });
+                                            },
+                                            child: const Padding(
+                                              padding: EdgeInsets.symmetric(vertical: 16.0),
+                                              child: Text("Desktop controls"),
+                                            ),
+                                          ),
+                                        ),
+                                      ],
+                                    ),
+                                    if (Platform.isAndroid)
+                                      ListTile(
+                                        title: const Text("Delay"),
+                                        subtitle: DelaySlider(
                   delay:
                       _chewieController?.progressIndicatorDelay?.inMilliseconds,
-                  onSave: (delay) async {
-                    if (delay != null) {
-                      bufferDelay = delay == 0 ? null : delay;
-                      await initializePlayer();
-                    }
-                  },
-                ),
-              )
-          ],
-        ),
+                                          onSave: (delay) async {
+                                            if (delay != null) {
+                                              bufferDelay = delay == 0 ? null : delay;
+                                              await initializePlayer();
+                                            }
+                                          },
+                                        ),
+                                      )
+                                  ],
+                                ),
       ),
     );
   }

--- a/example/lib/app/app.dart
+++ b/example/lib/app/app.dart
@@ -119,7 +119,7 @@ class _ChewieDemoState extends State<ChewieDemo> {
       additionalOptions: (context) {
         return <OptionItem>[
           OptionItem(
-            onTap: toggleVideo,
+            onTap: (context) => toggleVideo(),
             iconData: Icons.live_tv_sharp,
             title: 'Toggle Video Src',
           ),
@@ -158,7 +158,7 @@ class _ChewieDemoState extends State<ChewieDemo> {
 
   int currPlayIndex = 0;
 
-  Future<void> toggleVideo(BuildContext context) async {
+  Future<void> toggleVideo() async {
     await _videoPlayerController1.pause();
     currPlayIndex += 1;
     if (currPlayIndex >= srcs.length) {

--- a/example/lib/app/app.dart
+++ b/example/lib/app/app.dart
@@ -175,157 +175,157 @@ class _ChewieDemoState extends State<ChewieDemo> {
         platform: _platform ?? Theme.of(context).platform,
       ),
       home: Scaffold(
-                                appBar: AppBar(
-                                  title: Text(widget.title),
-                                ),
-                                body: Column(
-                                  children: <Widget>[
-                                    Expanded(
-                                      child: Center(
-                                        child: _chewieController != null &&
-                                                _chewieController!
-                                                    .videoPlayerController.value.isInitialized
-                                            ? Chewie(
-                                                controller: _chewieController!,
-                                              )
-                                            : const Column(
-                                                mainAxisAlignment: MainAxisAlignment.center,
-                                                children: [
-                                                  CircularProgressIndicator(),
-                                                  SizedBox(height: 20),
-                                                  Text('Loading'),
-                                                ],
-                                              ),
-                                      ),
-                                    ),
-                                    TextButton(
-                                      onPressed: () {
-                                        _chewieController?.enterFullScreen();
-                                      },
-                                      child: const Text('Fullscreen'),
-                                    ),
-                                    Row(
-                                      children: <Widget>[
-                                        Expanded(
-                                          child: TextButton(
-                                            onPressed: () {
-                                              setState(() {
-                                                _videoPlayerController1.pause();
-                                                _videoPlayerController1.seekTo(Duration.zero);
-                                                _createChewieController();
-                                              });
-                                            },
-                                            child: const Padding(
-                                              padding: EdgeInsets.symmetric(vertical: 16.0),
-                                              child: Text("Landscape Video"),
-                                            ),
-                                          ),
-                                        ),
-                                        Expanded(
-                                          child: TextButton(
-                                            onPressed: () {
-                                              setState(() {
-                                                _videoPlayerController2.pause();
-                                                _videoPlayerController2.seekTo(Duration.zero);
-                                                _chewieController = _chewieController!.copyWith(
-                                                  videoPlayerController: _videoPlayerController2,
-                                                  autoPlay: true,
-                                                  looping: true,
-                                                  /* subtitle: Subtitles([
-                                Subtitle(
-                                  index: 0,
-                                  start: Duration.zero,
-                                  end: const Duration(seconds: 10),
-                                  text: 'Hello from subtitles',
-                                ),
-                                Subtitle(
-                                  index: 0,
-                                  start: const Duration(seconds: 10),
-                                  end: const Duration(seconds: 20),
-                                  text: 'Whats up? :)',
-                                ),
-                              ]),
-                              subtitleBuilder: (context, subtitle) => Container(
-                                padding: const EdgeInsets.all(10.0),
-                                child: Text(
-                                  subtitle,
-                                  style: const TextStyle(color: Colors.white),
-                                ),
-                              ), */
-                                                );
-                                              });
-                                            },
-                                            child: const Padding(
-                                              padding: EdgeInsets.symmetric(vertical: 16.0),
-                                              child: Text("Portrait Video"),
-                                            ),
-                                          ),
-                                        )
-                                      ],
-                                    ),
-                                    Row(
-                                      children: <Widget>[
-                                        Expanded(
-                                          child: TextButton(
-                                            onPressed: () {
-                                              setState(() {
-                                                _platform = TargetPlatform.android;
-                                              });
-                                            },
-                                            child: const Padding(
-                                              padding: EdgeInsets.symmetric(vertical: 16.0),
-                                              child: Text("Android controls"),
-                                            ),
-                                          ),
-                                        ),
-                                        Expanded(
-                                          child: TextButton(
-                                            onPressed: () {
-                                              setState(() {
-                                                _platform = TargetPlatform.iOS;
-                                              });
-                                            },
-                                            child: const Padding(
-                                              padding: EdgeInsets.symmetric(vertical: 16.0),
-                                              child: Text("iOS controls"),
-                                            ),
-                                          ),
-                                        )
-                                      ],
-                                    ),
-                                    Row(
-                                      children: <Widget>[
-                                        Expanded(
-                                          child: TextButton(
-                                            onPressed: () {
-                                              setState(() {
-                                                _platform = TargetPlatform.windows;
-                                              });
-                                            },
-                                            child: const Padding(
-                                              padding: EdgeInsets.symmetric(vertical: 16.0),
-                                              child: Text("Desktop controls"),
-                                            ),
-                                          ),
-                                        ),
-                                      ],
-                                    ),
-                                    if (Platform.isAndroid)
-                                      ListTile(
-                                        title: const Text("Delay"),
-                                        subtitle: DelaySlider(
+        appBar: AppBar(
+          title: Text(widget.title),
+        ),
+        body: Column(
+          children: <Widget>[
+            Expanded(
+              child: Center(
+                child: _chewieController != null &&
+                        _chewieController!
+                            .videoPlayerController.value.isInitialized
+                    ? Chewie(
+                        controller: _chewieController!,
+                      )
+                    : const Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          CircularProgressIndicator(),
+                          SizedBox(height: 20),
+                          Text('Loading'),
+                        ],
+                      ),
+              ),
+            ),
+            TextButton(
+              onPressed: () {
+                _chewieController?.enterFullScreen();
+              },
+              child: const Text('Fullscreen'),
+            ),
+            Row(
+              children: <Widget>[
+                Expanded(
+                  child: TextButton(
+                    onPressed: () {
+                      setState(() {
+                        _videoPlayerController1.pause();
+                        _videoPlayerController1.seekTo(Duration.zero);
+                        _createChewieController();
+                      });
+                    },
+                    child: const Padding(
+                      padding: EdgeInsets.symmetric(vertical: 16.0),
+                      child: Text("Landscape Video"),
+                    ),
+                  ),
+                ),
+                Expanded(
+                  child: TextButton(
+                    onPressed: () {
+                      setState(() {
+                        _videoPlayerController2.pause();
+                        _videoPlayerController2.seekTo(Duration.zero);
+                        _chewieController = _chewieController!.copyWith(
+                          videoPlayerController: _videoPlayerController2,
+                          autoPlay: true,
+                          looping: true,
+                          /* subtitle: Subtitles([
+                            Subtitle(
+                              index: 0,
+                              start: Duration.zero,
+                              end: const Duration(seconds: 10),
+                              text: 'Hello from subtitles',
+                            ),
+                            Subtitle(
+                              index: 0,
+                              start: const Duration(seconds: 10),
+                              end: const Duration(seconds: 20),
+                              text: 'Whats up? :)',
+                            ),
+                          ]),
+                          subtitleBuilder: (context, subtitle) => Container(
+                            padding: const EdgeInsets.all(10.0),
+                            child: Text(
+                              subtitle,
+                              style: const TextStyle(color: Colors.white),
+                            ),
+                          ), */
+                        );
+                      });
+                    },
+                    child: const Padding(
+                      padding: EdgeInsets.symmetric(vertical: 16.0),
+                      child: Text("Portrait Video"),
+                    ),
+                  ),
+                )
+              ],
+            ),
+            Row(
+              children: <Widget>[
+                Expanded(
+                  child: TextButton(
+                    onPressed: () {
+                      setState(() {
+                        _platform = TargetPlatform.android;
+                      });
+                    },
+                    child: const Padding(
+                      padding: EdgeInsets.symmetric(vertical: 16.0),
+                      child: Text("Android controls"),
+                    ),
+                  ),
+                ),
+                Expanded(
+                  child: TextButton(
+                    onPressed: () {
+                      setState(() {
+                        _platform = TargetPlatform.iOS;
+                      });
+                    },
+                    child: const Padding(
+                      padding: EdgeInsets.symmetric(vertical: 16.0),
+                      child: Text("iOS controls"),
+                    ),
+                  ),
+                )
+              ],
+            ),
+            Row(
+              children: <Widget>[
+                Expanded(
+                  child: TextButton(
+                    onPressed: () {
+                      setState(() {
+                        _platform = TargetPlatform.windows;
+                      });
+                    },
+                    child: const Padding(
+                      padding: EdgeInsets.symmetric(vertical: 16.0),
+                      child: Text("Desktop controls"),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            if (Platform.isAndroid)
+              ListTile(
+                title: const Text("Delay"),
+                subtitle: DelaySlider(
                   delay:
                       _chewieController?.progressIndicatorDelay?.inMilliseconds,
-                                          onSave: (delay) async {
-                                            if (delay != null) {
-                                              bufferDelay = delay == 0 ? null : delay;
-                                              await initializePlayer();
-                                            }
-                                          },
-                                        ),
-                                      )
-                                  ],
-                                ),
+                  onSave: (delay) async {
+                    if (delay != null) {
+                      bufferDelay = delay == 0 ? null : delay;
+                      await initializePlayer();
+                    }
+                  },
+                ),
+              )
+          ],
+        ),
       ),
     );
   }

--- a/lib/src/cupertino/widgets/cupertino_options_dialog.dart
+++ b/lib/src/cupertino/widgets/cupertino_options_dialog.dart
@@ -24,7 +24,7 @@ class _CupertinoOptionsDialogState extends State<CupertinoOptionsDialog> {
         actions: widget.options
             .map(
               (option) => CupertinoActionSheetAction(
-                onPressed: () => option.onTap!(),
+                onPressed: () => option.onTap!(context),
                 child: Text(option.title),
               ),
             )

--- a/lib/src/cupertino/widgets/cupertino_options_dialog.dart
+++ b/lib/src/cupertino/widgets/cupertino_options_dialog.dart
@@ -24,7 +24,7 @@ class _CupertinoOptionsDialogState extends State<CupertinoOptionsDialog> {
         actions: widget.options
             .map(
               (option) => CupertinoActionSheetAction(
-                onPressed: () => option.onTap!(context),
+                onPressed: () => option.onTap(context),
                 child: Text(option.title),
               ),
             )

--- a/lib/src/material/material_controls.dart
+++ b/lib/src/material/material_controls.dart
@@ -161,7 +161,7 @@ class _MaterialControlsState extends State<MaterialControls>
     );
   }
 
-  Widget _buildOptionsButton() {
+  List<OptionItem> _buildOptions(BuildContext context) {
     final options = <OptionItem>[
       OptionItem(
         onTap: (context) async {
@@ -178,7 +178,10 @@ class _MaterialControlsState extends State<MaterialControls>
         chewieController.additionalOptions!(context).isNotEmpty) {
       options.addAll(chewieController.additionalOptions!(context));
     }
+    return options;
+  }
 
+  Widget _buildOptionsButton() {
     return AnimatedOpacity(
       opacity: notifier.hideStuff ? 0.0 : 1.0,
       duration: const Duration(milliseconds: 250),
@@ -187,14 +190,14 @@ class _MaterialControlsState extends State<MaterialControls>
           _hideTimer?.cancel();
 
           if (chewieController.optionsBuilder != null) {
-            await chewieController.optionsBuilder!(context, options);
+            await chewieController.optionsBuilder!(context, _buildOptions(context));
           } else {
             await showModalBottomSheet<OptionItem>(
               context: context,
               isScrollControlled: true,
               useRootNavigator: chewieController.useRootNavigator,
               builder: (context) => OptionsDialog(
-                options: options,
+                options: _buildOptions(context),
                 cancelButtonText:
                     chewieController.optionsTranslation?.cancelButtonText,
               ),

--- a/lib/src/material/material_controls.dart
+++ b/lib/src/material/material_controls.dart
@@ -164,7 +164,7 @@ class _MaterialControlsState extends State<MaterialControls>
   Widget _buildOptionsButton() {
     final options = <OptionItem>[
       OptionItem(
-        onTap: () async {
+        onTap: (context) async {
           Navigator.pop(context);
           _onSpeedButtonTap();
         },

--- a/lib/src/material/material_controls.dart
+++ b/lib/src/material/material_controls.dart
@@ -190,7 +190,8 @@ class _MaterialControlsState extends State<MaterialControls>
           _hideTimer?.cancel();
 
           if (chewieController.optionsBuilder != null) {
-            await chewieController.optionsBuilder!(context, _buildOptions(context));
+            await chewieController.optionsBuilder!(
+                context, _buildOptions(context));
           } else {
             await showModalBottomSheet<OptionItem>(
               context: context,

--- a/lib/src/material/material_desktop_controls.dart
+++ b/lib/src/material/material_desktop_controls.dart
@@ -155,7 +155,7 @@ class _MaterialDesktopControlsState extends State<MaterialDesktopControls>
   }) {
     final options = <OptionItem>[
       OptionItem(
-        onTap: () async {
+        onTap: (context) async {
           Navigator.pop(context);
           _onSpeedButtonTap();
         },

--- a/lib/src/material/widgets/options_dialog.dart
+++ b/lib/src/material/widgets/options_dialog.dart
@@ -28,7 +28,7 @@ class _OptionsDialogState extends State<OptionsDialog> {
             itemCount: widget.options.length,
             itemBuilder: (context, i) {
               return ListTile(
-                onTap: widget.options[i].onTap,
+                onTap: () => widget.options[i].onTap?.call(context),
                 leading: Icon(widget.options[i].iconData),
                 title: Text(widget.options[i].title),
                 subtitle: widget.options[i].subtitle != null

--- a/lib/src/material/widgets/options_dialog.dart
+++ b/lib/src/material/widgets/options_dialog.dart
@@ -28,7 +28,7 @@ class _OptionsDialogState extends State<OptionsDialog> {
             itemCount: widget.options.length,
             itemBuilder: (context, i) {
               return ListTile(
-                onTap: () => widget.options[i].onTap?.call(context),
+                onTap: () => widget.options[i].onTap(context),
                 leading: Icon(widget.options[i].iconData),
                 title: Text(widget.options[i].title),
                 subtitle: widget.options[i].subtitle != null

--- a/lib/src/models/option_item.dart
+++ b/lib/src/models/option_item.dart
@@ -8,13 +8,13 @@ class OptionItem {
     this.subtitle,
   });
 
-  Function()? onTap;
+  Function(BuildContext context)? onTap;
   IconData iconData;
   String title;
   String? subtitle;
 
   OptionItem copyWith({
-    Function()? onTap,
+    Function(BuildContext context)? onTap,
     IconData? iconData,
     String? title,
     String? subtitle,

--- a/lib/src/models/option_item.dart
+++ b/lib/src/models/option_item.dart
@@ -8,10 +8,10 @@ class OptionItem {
     this.subtitle,
   });
 
-  Function(BuildContext context)? onTap;
-  IconData iconData;
-  String title;
-  String? subtitle;
+  final void Function(BuildContext context) onTap;
+  final IconData iconData;
+  final String title;
+  final String? subtitle;
 
   OptionItem copyWith({
     Function(BuildContext context)? onTap,


### PR DESCRIPTION
**Fixed pop the wrong page when changing the speed**
Issue: https://github.com/fluttercommunity/chewie/issues/618

This was during the speed change and the use of additional options. This was due to the use of the wrong context. In order for the bottom sheet to close correctly, we need to use the context of the bottom sheet itself.
```
await showModalBottomSheet<OptionItem>(
              context: context,
              isScrollControlled: true,
              useRootNavigator: chewieController.useRootNavigator,
              builder: (context) => OptionsDialog(
                options: options,
                options: _buildOptions(context),
                cancelButtonText:
                    chewieController.optionsTranslation?.cancelButtonText,
              ),
```

In this regard, I had to add the `BuildContext context` parameter to the `OptionItem` model in `onTap` callback. Now there is no such problem.
`Function(BuildContext context)? onTap;`

Such a bug was noticed in a project where we use AutoRoute package, so maybe this bug has something to do with using this package.