### PR TITLE
Add workaround for invalid buffering info on android

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ Chewie uses the `video_player` under the hood and wraps it in a friendly Materia
 8.  🧪 [Example](#-example)
 9.  ⏪ [Migrating from Chewie < 0.9.0](#-migrating-from-chewie--090)
 10. 🗺️ [Roadmap](#%EF%B8%8F-roadmap)
-11. 📱 [iOS warning](#-ios-warning-)
+11. ⚠️ [Android warning](#-android-warning-)
+12. 📱 [iOS warning](#-ios-warning-)
 
 
 ## 🚨 IMPORTANT!!! (READ THIS FIRST)
@@ -285,6 +286,33 @@ final playerWidget = Chewie(
 - [ ] Re-design State-Manager with Provider
 - [ ] Screen-Mirroring / Casting (Google Chromecast)
 
+
+## ⚠️ Android warning
+
+There is an open [issue](https://github.com/flutter/flutter/issues/165149) that the buffering state of a video is not reported correctly. With this, the loading state is always triggered, hiding controls to play, pause or seek the video. A workaround was implemented until this is fixed, however it can't be perfect and still hides controls if seeking backwards while the video is paused, as a result of lack of correct buffering information (see #912).
+
+Add the following to partly fix this behavior:
+
+```dart
+  // Your init code can be above
+  videoController.addListener(yourListeningMethod);
+
+  // ...
+
+  bool wasPlayingBefore = false;
+  void yourListeningMethod() {
+    if (!videoController.value.isPlaying && !wasPlayingBefore) {
+      // -> Workaround if seekTo another position while it was paused before.
+      //    On Android this might lead to infinite loading, so just play the
+      //    video again.
+      videoController.play();
+    }
+
+    wasPlayingBefore = videoController.value.isPlaying;
+
+  // ...
+  }
+```
 
 ## 📱 iOS warning 
 

--- a/README.md
+++ b/README.md
@@ -314,6 +314,15 @@ Add the following to partly fix this behavior:
   }
 ```
 
+You can also disable the loading spinner entirely to fix this problem in a more _complete_ way, however will remove the loading indicator if a video is buffering.
+
+```dart
+_chewieController = ChewieController(
+  videoPlayerController: _videoPlayerController,
+  progressIndicatorDelay: Platform.isAndroid ? const Duration(days: 1) : null,
+);
+```
+
 ## 📱 iOS warning 
 
 The video_player plugin used by chewie will only work in iOS simulators if you are on flutter 1.26.0 or above. You may need to switch to the beta channel `flutter channel beta`

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Chewie uses the `video_player` under the hood and wraps it in a friendly Materia
 8.  🧪 [Example](#-example)
 9.  ⏪ [Migrating from Chewie < 0.9.0](#-migrating-from-chewie--090)
 10. 🗺️ [Roadmap](#%EF%B8%8F-roadmap)
-11. ⚠️ [Android warning](#-android-warning-)
-12. 📱 [iOS warning](#-ios-warning-)
+11. ⚠️ [Android warning](#%EF%B8%8F-android-warning)
+12. 📱 [iOS warning](#-ios-warning)
 
 
 ## 🚨 IMPORTANT!!! (READ THIS FIRST)

--- a/lib/src/cupertino/cupertino_controls.dart
+++ b/lib/src/cupertino/cupertino_controls.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:io';
 import 'dart:math' as math;
 import 'dart:ui' as ui;
 
@@ -811,33 +810,7 @@ class _CupertinoControlsState extends State<CupertinoControls>
   void _updateState() {
     if (!mounted) return;
 
-    late final bool buffering;
-
-    if (Platform.isAndroid) {
-      if (controller.value.isBuffering) {
-        // -> Check if we actually buffer, as android has a bug preventing to
-        //    get the correct buffering state from this single bool.
-        final VideoPlayerValue value = controller.value;
-
-        final int position = value.position.inMilliseconds;
-
-        // Special case, if the video is finished, we don't want to show the
-        // buffering indicator anymore
-        if (position >= value.duration.inMilliseconds) {
-          buffering = false;
-        } else {
-          final int buffer =
-              value.buffered.lastOrNull?.end.inMilliseconds ?? -1;
-
-          buffering = position >= buffer;
-        }
-      } else {
-        // -> No buffering
-        buffering = false;
-      }
-    } else {
-      buffering = controller.value.isBuffering;
-    }
+    final bool buffering = getIsBuffering(controller);
 
     // display the progress bar indicator only after the buffering delay if it has been set
     if (chewieController.progressIndicatorDelay != null) {

--- a/lib/src/cupertino/cupertino_controls.dart
+++ b/lib/src/cupertino/cupertino_controls.dart
@@ -818,10 +818,19 @@ class _CupertinoControlsState extends State<CupertinoControls>
         // -> Check if we actually buffer, as android has a bug preventing to
         //    get the correct buffering state from this single bool.
         final VideoPlayerValue value = controller.value;
-        final int buffer = value.buffered.lastOrNull?.end.inMilliseconds ?? -1;
+
         final int position = value.position.inMilliseconds;
 
-        buffering = position >= buffer;
+        // Special case, if the video is finished, we don't want to show the
+        // buffering indicator anymore
+        if (position >= value.duration.inMilliseconds) {
+          buffering = false;
+        } else {
+          final int buffer =
+              value.buffered.lastOrNull?.end.inMilliseconds ?? -1;
+
+          buffering = position >= buffer;
+        }
       } else {
         // -> No buffering
         buffering = false;

--- a/lib/src/cupertino/cupertino_controls.dart
+++ b/lib/src/cupertino/cupertino_controls.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 import 'dart:math' as math;
 import 'dart:ui' as ui;
 
@@ -810,9 +811,28 @@ class _CupertinoControlsState extends State<CupertinoControls>
   void _updateState() {
     if (!mounted) return;
 
+    late final bool buffering;
+
+    if (Platform.isAndroid) {
+      if (controller.value.isBuffering) {
+        // -> Check if we actually buffer, as android has a bug preventing to
+        //    get the correct buffering state from this single bool.
+        final VideoPlayerValue value = controller.value;
+        final int buffer = value.buffered.lastOrNull?.end.inMilliseconds ?? -1;
+        final int position = value.position.inMilliseconds;
+
+        buffering = position >= buffer;
+      } else {
+        // -> No buffering
+        buffering = false;
+      }
+    } else {
+      buffering = controller.value.isBuffering;
+    }
+
     // display the progress bar indicator only after the buffering delay if it has been set
     if (chewieController.progressIndicatorDelay != null) {
-      if (controller.value.isBuffering) {
+      if (buffering) {
         _bufferingDisplayTimer ??= Timer(
           chewieController.progressIndicatorDelay!,
           _bufferingTimerTimeout,
@@ -823,7 +843,7 @@ class _CupertinoControlsState extends State<CupertinoControls>
         _displayBufferingIndicator = false;
       }
     } else {
-      _displayBufferingIndicator = controller.value.isBuffering;
+      _displayBufferingIndicator = buffering;
     }
 
     setState(() {

--- a/lib/src/helpers/utils.dart
+++ b/lib/src/helpers/utils.dart
@@ -1,5 +1,4 @@
-import 'dart:io';
-
+import 'package:flutter/foundation.dart';
 import 'package:video_player/video_player.dart';
 
 String formatDuration(Duration position) {
@@ -38,7 +37,7 @@ String formatDuration(Duration position) {
 bool getIsBuffering(VideoPlayerController controller) {
   final VideoPlayerValue value = controller.value;
 
-  if (Platform.isAndroid) {
+  if (defaultTargetPlatform == TargetPlatform.android) {
     if (value.isBuffering) {
       // -> Check if we actually buffer, as android has a bug preventing to
       //    get the correct buffering state from this single bool.

--- a/lib/src/helpers/utils.dart
+++ b/lib/src/helpers/utils.dart
@@ -1,3 +1,7 @@
+import 'dart:io';
+
+import 'package:video_player/video_player.dart';
+
 String formatDuration(Duration position) {
   final ms = position.inMilliseconds;
 
@@ -29,4 +33,31 @@ String formatDuration(Duration position) {
       '${hoursString == '00' ? '' : '$hoursString:'}$minutesString:$secondsString';
 
   return formattedTime;
+}
+
+bool getIsBuffering(VideoPlayerController controller) {
+  final VideoPlayerValue value = controller.value;
+
+  if (Platform.isAndroid) {
+    if (value.isBuffering) {
+      // -> Check if we actually buffer, as android has a bug preventing to
+      //    get the correct buffering state from this single bool.
+      final int position = value.position.inMilliseconds;
+
+      // Special case, if the video is finished, we don't want to show the
+      // buffering indicator anymore
+      if (position >= value.duration.inMilliseconds) {
+        return false;
+      } else {
+        final int buffer = value.buffered.lastOrNull?.end.inMilliseconds ?? -1;
+
+        return position >= buffer;
+      }
+    } else {
+      // -> No buffering
+      return false;
+    }
+  }
+
+  return value.isBuffering;
 }

--- a/lib/src/helpers/utils.dart
+++ b/lib/src/helpers/utils.dart
@@ -34,6 +34,11 @@ String formatDuration(Duration position) {
   return formattedTime;
 }
 
+/// Get the current buffering state of the video player. Will invoke a
+/// Workaround for Android, as a bug in the video_player plugin prevents to get
+/// the actual buffering state, always returning true and breaking ui elements.
+/// For this, the actual buffer position is used to determine if the video is
+/// buffering or not. See #912 for more details.
 bool getIsBuffering(VideoPlayerController controller) {
   final VideoPlayerValue value = controller.value;
 

--- a/lib/src/helpers/utils.dart
+++ b/lib/src/helpers/utils.dart
@@ -34,11 +34,15 @@ String formatDuration(Duration position) {
   return formattedTime;
 }
 
-/// Get the current buffering state of the video player. Will invoke a
-/// Workaround for Android, as a bug in the video_player plugin prevents to get
-/// the actual buffering state, always returning true and breaking ui elements.
+/// Gets the current buffering state of the video player.
+///
+/// For Android, it will use a workaround due to a [bug](https://github.com/flutter/flutter/issues/165149)
+/// affecting the `video_player` plugin, preventing it from getting the
+/// actual buffering state. This currently results in the `VideoPlayerController` always buffering,
+/// thus breaking UI elements.
+///
 /// For this, the actual buffer position is used to determine if the video is
-/// buffering or not. See #912 for more details.
+/// buffering or not. See Issue [#912](https://github.com/fluttercommunity/chewie/pull/912) for more details.
 bool getIsBuffering(VideoPlayerController controller) {
   final VideoPlayerValue value = controller.value;
 

--- a/lib/src/material/material_controls.dart
+++ b/lib/src/material/material_controls.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:io';
 
 import 'package:chewie/src/center_play_button.dart';
 import 'package:chewie/src/center_seek_button.dart';
@@ -646,33 +645,7 @@ class _MaterialControlsState extends State<MaterialControls>
   void _updateState() {
     if (!mounted) return;
 
-    late final bool buffering;
-
-    if (Platform.isAndroid) {
-      if (controller.value.isBuffering) {
-        // -> Check if we actually buffer, as android has a bug preventing to
-        //    get the correct buffering state from this single bool.
-        final VideoPlayerValue value = controller.value;
-
-        final int position = value.position.inMilliseconds;
-
-        // Special case, if the video is finished, we don't want to show the
-        // buffering indicator anymore
-        if (position >= value.duration.inMilliseconds) {
-          buffering = false;
-        } else {
-          final int buffer =
-              value.buffered.lastOrNull?.end.inMilliseconds ?? -1;
-
-          buffering = position >= buffer;
-        }
-      } else {
-        // -> No buffering
-        buffering = false;
-      }
-    } else {
-      buffering = controller.value.isBuffering;
-    }
+    final bool buffering = getIsBuffering(controller);
 
     // display the progress bar indicator only after the buffering delay if it has been set
     if (chewieController.progressIndicatorDelay != null) {

--- a/lib/src/material/material_controls.dart
+++ b/lib/src/material/material_controls.dart
@@ -653,10 +653,19 @@ class _MaterialControlsState extends State<MaterialControls>
         // -> Check if we actually buffer, as android has a bug preventing to
         //    get the correct buffering state from this single bool.
         final VideoPlayerValue value = controller.value;
-        final int buffer = value.buffered.lastOrNull?.end.inMilliseconds ?? -1;
+
         final int position = value.position.inMilliseconds;
 
-        buffering = position >= buffer;
+        // Special case, if the video is finished, we don't want to show the
+        // buffering indicator anymore
+        if (position >= value.duration.inMilliseconds) {
+          buffering = false;
+        } else {
+          final int buffer =
+              value.buffered.lastOrNull?.end.inMilliseconds ?? -1;
+
+          buffering = position >= buffer;
+        }
       } else {
         // -> No buffering
         buffering = false;

--- a/lib/src/material/material_desktop_controls.dart
+++ b/lib/src/material/material_desktop_controls.dart
@@ -589,10 +589,19 @@ class _MaterialDesktopControlsState extends State<MaterialDesktopControls>
         // -> Check if we actually buffer, as android has a bug preventing to
         //    get the correct buffering state from this single bool.
         final VideoPlayerValue value = controller.value;
-        final int buffer = value.buffered.lastOrNull?.end.inMilliseconds ?? -1;
+
         final int position = value.position.inMilliseconds;
 
-        buffering = position >= buffer;
+        // Special case, if the video is finished, we don't want to show the
+        // buffering indicator anymore
+        if (position >= value.duration.inMilliseconds) {
+          buffering = false;
+        } else {
+          final int buffer =
+              value.buffered.lastOrNull?.end.inMilliseconds ?? -1;
+
+          buffering = position >= buffer;
+        }
       } else {
         // -> No buffering
         buffering = false;

--- a/lib/src/material/material_desktop_controls.dart
+++ b/lib/src/material/material_desktop_controls.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:io';
 
 import 'package:chewie/src/animated_play_pause.dart';
 import 'package:chewie/src/center_play_button.dart';
@@ -582,33 +581,7 @@ class _MaterialDesktopControlsState extends State<MaterialDesktopControls>
   void _updateState() {
     if (!mounted) return;
 
-    late final bool buffering;
-
-    if (Platform.isAndroid) {
-      if (controller.value.isBuffering) {
-        // -> Check if we actually buffer, as android has a bug preventing to
-        //    get the correct buffering state from this single bool.
-        final VideoPlayerValue value = controller.value;
-
-        final int position = value.position.inMilliseconds;
-
-        // Special case, if the video is finished, we don't want to show the
-        // buffering indicator anymore
-        if (position >= value.duration.inMilliseconds) {
-          buffering = false;
-        } else {
-          final int buffer =
-              value.buffered.lastOrNull?.end.inMilliseconds ?? -1;
-
-          buffering = position >= buffer;
-        }
-      } else {
-        // -> No buffering
-        buffering = false;
-      }
-    } else {
-      buffering = controller.value.isBuffering;
-    }
+    final bool buffering = getIsBuffering(controller);
 
     // display the progress bar indicator only after the buffering delay if it has been set
     if (chewieController.progressIndicatorDelay != null) {


### PR DESCRIPTION
## Info
As already described in multiple issues, there is currently a problem with android reporting "isBuffering" with true even if the video is already playing, preventing the video controls to be displayed. This is a workaround, checking (on android only) if the video is actually buffering. Tested with a network- and file-based video.

>NOTE: This is only a workaround until video_player and flutter is fixed. See https://github.com/flutter/flutter/issues/165149 for more information. Also thanks to @wenwangwill who added a workaround as comment i got inspired from.

## Additional Issues not solved
If pausing the video and seeking to some point (using seekTo, so clicking on the progress bar) still leads to the infinit loading bar, as no callback is called by the video controller and thus the buffering not updated.

As workaround, just start playing on seekTo like this:

```dart
  // Your init code can be above
  videoController.addListener(yourListeningMethod);

  // ...

  bool wasPlayingBefore = false;
  void yourListeningMethod() {
    if (!videoController.value.isPlaying && !wasPlayingBefore) {
      // -> Workaround if seekTo another position while it was paused before
      //    on Android this might lead to infinite loading, so just play the
      //    video again.
      videoController.play();
    }

    wasPlayingBefore = videoController.value.isPlaying;

  // ...
  }

```

## Related to
#909
#907 
#906
#903
