### PR TITLE
Resolve issue where 'subtitleOn' doesn't enable subtitles by default on iOS

### DIFF
--- a/lib/src/cupertino/cupertino_controls.dart
+++ b/lib/src/cupertino/cupertino_controls.dart
@@ -649,7 +649,7 @@ class _CupertinoControlsState extends State<CupertinoControls>
   }
 
   Future<void> _initialize() async {
-    chewieController.showSubtitles &&
+    _subtitleOn = chewieController.showSubtitles &&
         (chewieController.subtitle?.isNotEmpty ?? false);
     controller.addListener(_updateState);
 


### PR DESCRIPTION
This pull request includes a small change to the `lib/src/cupertino/cupertino_controls.dart` file. It updates the `_initialize` method to correctly assign the `_subtitleOn` flag based on `chewieController.showSubtitles` and whether the `subtitle` is not empty.

Previously, the code was:

```dart

chewieController.showSubtitles &&
    (chewieController.subtitle?.isNotEmpty ?? false);

```

This line had no effects and was effectively dead code. The condition was evaluated but not used.

The updated version assigns the result of the condition to `_subtitleOn`:

```dart

_subtitleOn = chewieController.showSubtitles &&
    (chewieController.subtitle?.isNotEmpty ?? false);

```

This change ensures that subtitles are properly enabled by default when the `showSubtitles` flag is true and a non-empty subtitle is present.

### File Changes

- [`[lib/src/cupertino/cupertino_controls.dart](https://www.notion.so/1cfd8b130ac680f381d4c435719819ff?pvs=21)`](https://www.notion.so/1cfd8b130ac680f381d4c435719819ff?pvs=21): Updated `_initialize` method to assign `_subtitleOn`.