### PR TITLE
Fix(web): Keep playback when entering/exiting fullscreen on web

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [Unreleased]
+* 🛠️ Fix web fullscreen playback on enter/exit: preserve play/pause state and resume stream on web. Avoids stall requiring manual pause/play.
+
 ## [1.12.1]
 * 🛠️ [#920](https://github.com/fluttercommunity/chewie/pull/920): Fix zoomAndPan not having an effect. Thanks [abalmagd](https://github.com/abalmagd).
 
@@ -388,4 +391,3 @@ Initial version of Chewie, the video player with a heart of gold.
   * Includes Material Player Controls
   * Includes Cupertino Player Controls
   * Spike version: Focus on good looking UI. Internal code is sloppy, needs a refactor and tests
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,3 @@
-## [Unreleased]
-* 🛠️ Fix web fullscreen playback on enter/exit: preserve play/pause state and resume stream on web. Avoids stall requiring manual pause/play.
-
 ## [1.12.1]
 * 🛠️ [#920](https://github.com/fluttercommunity/chewie/pull/920): Fix zoomAndPan not having an effect. Thanks [abalmagd](https://github.com/abalmagd).
 


### PR DESCRIPTION
## Description
- Problem: On Flutter Web, entering or exiting fullscreen can stall playback or force a pause; users often need to manually pause -> play to recover.
- Root cause: The platform view rebuild during fullscreen disrupts the HTML video element’s stream/state.

## Solution
- Enter fullscreen _(web-only)_: After the first fullscreen frame, force a quick pause -> 10ms delay -> play if the video was previously playing; if it was paused, briefly play then pause to prime a frame.
- Exit fullscreen _(web-only)_: Re-initialize the `VideoPlayerController`, seek back to the previous position, and restore the prior play/pause state.
- All changes are guarded by `kIsWeb`; non-web platforms are unaffected.