### PR TITLE
Added an option to use the native fullscreen of a browser in webapps

### DIFF
--- a/lib/src/chewie_player.dart
+++ b/lib/src/chewie_player.dart
@@ -12,6 +12,7 @@ import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 import 'package:video_player/video_player.dart';
 import 'package:wakelock_plus/wakelock_plus.dart';
+import 'package:chewie/src/helpers/fullscreen_controller.dart';
 
 typedef ChewieRoutePageBuilder =
     Widget Function(
@@ -139,7 +140,7 @@ class ChewieState extends State<Chewie> {
       ),
     );
 
-    if (kIsWeb && !_resumeAppliedInFullScreen) {
+    if (kIsWeb && !_resumeAppliedInFullScreen && !widget.controller.useNativeWebFullscreen) {
       _resumeAppliedInFullScreen = true;
       WidgetsBinding.instance.addPostFrameCallback((_) async {
         if (!mounted) return;
@@ -189,7 +190,7 @@ class ChewieState extends State<Chewie> {
 
     final wasPlaying = widget.controller.videoPlayerController.value.isPlaying;
 
-    if (kIsWeb) {
+    if (kIsWeb && !widget.controller.useNativeWebFullscreen) {
       await _reInitializeControllers(wasPlaying);
     }
 
@@ -335,12 +336,16 @@ class ChewieController extends ChangeNotifier {
     this.hideControlsTimer = defaultHideControlsTimer,
     this.controlsSafeAreaMinimum = EdgeInsets.zero,
     this.pauseOnBackgroundTap = false,
+    this.useNativeWebFullscreen = true,
   }) : assert(
          playbackSpeeds.every((speed) => speed > 0),
          'The playbackSpeeds values must all be greater than 0',
-       ) {
+       ),
+      textureId = _textureCounter++ {
     _initialize();
   }
+
+  static int _textureCounter = 1;
 
   ChewieController copyWith({
     VideoPlayerController? videoPlayerController,
@@ -394,6 +399,7 @@ class ChewieController extends ChangeNotifier {
     )?
     routePageBuilder,
     bool? pauseOnBackgroundTap,
+    bool? useNativeWebFullscreen,
   }) {
     return ChewieController(
       draggableProgressBar: draggableProgressBar ?? this.draggableProgressBar,
@@ -458,6 +464,7 @@ class ChewieController extends ChangeNotifier {
       progressIndicatorDelay:
           progressIndicatorDelay ?? this.progressIndicatorDelay,
       pauseOnBackgroundTap: pauseOnBackgroundTap ?? this.pauseOnBackgroundTap,
+      useNativeWebFullscreen: useNativeWebFullscreen ?? this.useNativeWebFullscreen,
     );
   }
 
@@ -630,6 +637,16 @@ class ChewieController extends ChangeNotifier {
   /// Defines if the player should pause when the background is tapped
   final bool pauseOnBackgroundTap;
 
+  // The texture ID of the video player.
+  final int textureId;
+
+  /// Defines if native fullscreen should be used on web
+  /// Default: true
+  final bool useNativeWebFullscreen;
+
+  // Internal Fullscreen Controller for native web fullscreen handling
+  final FullscreenController _fullscreenController = FullscreenController();
+
   static ChewieController of(BuildContext context) {
     final chewieControllerProvider = context
         .dependOnInheritedWidgetOfExactType<ChewieControllerProvider>()!;
@@ -686,6 +703,10 @@ class ChewieController extends ChangeNotifier {
   }
 
   void toggleFullScreen() {
+     if (kIsWeb && useNativeWebFullscreen) {
+      _fullscreenController.toggleFullscreen(textureId);
+      return;
+    }
     _isFullScreen = !_isFullScreen;
     notifyListeners();
   }

--- a/lib/src/helpers/fullscreen_controller.dart
+++ b/lib/src/helpers/fullscreen_controller.dart
@@ -1,1 +1,1 @@
-export 'fullscreen_controller_unsupported.dart' if (dart.library.html) 'fullscreen_controller_web.dart';
+export 'fullscreen_controller_unsupported.dart' if (dart.library.js_interop) 'fullscreen_controller_web.dart';

--- a/lib/src/helpers/fullscreen_controller.dart
+++ b/lib/src/helpers/fullscreen_controller.dart
@@ -1,0 +1,1 @@
+export 'fullscreen_controller_unsupported.dart' if (dart.library.html) 'fullscreen_controller_web.dart';

--- a/lib/src/helpers/fullscreen_controller_unsupported.dart
+++ b/lib/src/helpers/fullscreen_controller_unsupported.dart
@@ -1,0 +1,6 @@
+class FullscreenController {
+  void toggleFullscreen(int textureId) {
+    // This is a stub for non-web platforms.
+    // Fullscreen is handled by the chewie controller itself on mobile.
+  }
+}

--- a/lib/src/helpers/fullscreen_controller_web.dart
+++ b/lib/src/helpers/fullscreen_controller_web.dart
@@ -1,0 +1,35 @@
+import 'package:web/web.dart' as web;
+import 'package:flutter/foundation.dart';
+
+class FullscreenController {
+  void toggleFullscreen(int textureId) {
+
+    final videoElement = web.document.getElementById('videoElement-$textureId');
+
+    if (videoElement == null) {
+      // As a fallback, we try to find ANY video element. This is not robust if there are multiple videos.
+      final fallbackVideoElement = web.document.querySelector('video');
+      if (fallbackVideoElement != null) {
+        _requestFullscreen(fallbackVideoElement);
+      } else {
+        debugPrint('Error: No video element found for fullscreen toggle.');
+      }
+      return;
+    }
+
+    _requestFullscreen(videoElement);
+  }
+
+  void _requestFullscreen(web.Element videoElement) {
+    if (web.document.fullscreenElement == null) {
+      try {
+        videoElement.requestFullscreen();
+      } catch (e) {
+        debugPrint('Error requesting fullscreen: $e');
+      }
+    } else {
+      web.document.exitFullscreen();
+    }
+  }
+}
+

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   provider: ^6.1.5+1
   video_player: ^2.10.0
   wakelock_plus: ^1.3.2
+  web: ^1.1.1
 
 dev_dependencies:
   flutter_test:

--- a/test/chewie_controller_test.dart
+++ b/test/chewie_controller_test.dart
@@ -1,0 +1,68 @@
+import 'package:chewie/chewie.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:video_player/video_player.dart';
+
+void main() {
+  group('ChewieController', () {
+    late VideoPlayerController videoPlayerController;
+
+    setUp(() {
+      videoPlayerController = VideoPlayerController.networkUrl(
+        Uri.parse('https://example.com/video.mp4'),
+      );
+    });
+
+    test('sets useNativeWebFullscreen to true by default', () {
+      final controller = ChewieController(
+        videoPlayerController: videoPlayerController,
+      );
+
+      expect(controller.useNativeWebFullscreen, true);
+
+      controller.dispose();
+    });
+
+    test('assigns unique textureId to each controller', () {
+      final controller1 = ChewieController(
+        videoPlayerController: videoPlayerController,
+      );
+      final controller2 = ChewieController(
+        videoPlayerController: videoPlayerController,
+      );
+
+      expect(controller1.textureId, isNot(controller2.textureId));
+
+      controller1.dispose();
+      controller2.dispose();
+    });
+
+    test('toggleFullScreen toggles isFullScreen on non-web', () {
+      final controller = ChewieController(
+        videoPlayerController: videoPlayerController,
+      );
+
+      expect(controller.isFullScreen, false);
+      controller.toggleFullScreen();
+      expect(controller.isFullScreen, true);
+      controller.toggleFullScreen();
+      expect(controller.isFullScreen, false);
+
+      controller.dispose();
+    });
+
+    test('copyWith preserves useNativeWebFullscreen', () {
+      final controller = ChewieController(
+        videoPlayerController: videoPlayerController,
+        useNativeWebFullscreen: false,
+      );
+
+      expect(controller.useNativeWebFullscreen, false);
+
+      final copied = controller.copyWith(useNativeWebFullscreen: true);
+      expect(copied.useNativeWebFullscreen, true);
+
+      controller.dispose();
+      copied.dispose();
+    });
+  });
+}


### PR DESCRIPTION
This PR introduces native web fullscreen support to provide a more immersive video playback experience in web browsers.


### Problem
Currently, the fullscreen mode in chewie on web has some limitations:

- **Browser UI remains visible:** When entering fullscreen, browser elements like the address bar and tabs are still visible, which is not a true fullscreen experience.
- **Constrained by parent containers:** in a width restriced webapp the fullscreen mode of the player is also restricted -> removing this restriction with a variable set in a provider leads to problems with the player notifier

### Solution
 `useNativeWebFullscreen` flag: A new boolean flag, `useNativeWebFullscreen`, has been added to `ChewieController`. This flag is true by default. When set to false, it reverts to the original fullscreen behavior.
