### PR TITLE
fix: add mounted check in _startHideTimer to prevent setState after dispose

### DIFF
--- a/lib/src/material/material_controls.dart
+++ b/lib/src/material/material_controls.dart
@@ -594,6 +594,7 @@ class _MaterialControlsState extends State<MaterialControls>
         ? ChewieController.defaultHideControlsTimer
         : chewieController.hideControlsTimer;
     _hideTimer = Timer(hideControlsTimer, () {
+      if (!mounted) return;
       setState(() {
         notifier.hideStuff = true;
       });


### PR DESCRIPTION
Problem:
_startHideTimer calls setState inside a Timer callback without checking mounted first. If the widget is disposed before the timer fires (e.g. user navigates away), this causes a fatal crash: Null check operator used on a null value.

Fix:
Add if (!mounted) return; before setState, following the same pattern already used in _bufferingTimerTimeout and _updateState (PR #470).