### PR TITLE
feat: multi-track subtitle selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [Unreleased]
+* 💬 [#948](https://github.com/fluttercommunity/chewie/pull/948): Add source-agnostic multi-track subtitle selection to the Material controls, via the new `SubtitleTrack` model and `ChewieController.subtitleTracks` / `activeSubtitleTrackId` / `onSubtitleTrackChanged`, plus `setLiveSubtitle` for cues that stream in over time. Thanks [Ortes](https://github.com/Ortes).
+
 ## [1.15.0]
 * 🌐 [#946](https://github.com/fluttercommunity/chewie/pull/946): Web: enter the browser's native (OS-level) fullscreen via the Fullscreen API instead of only expanding the Flutter view inside the browser window. Pressing Escape to leave browser fullscreen also exits Chewie's fullscreen. Controlled by the new `ChewieController.useNativeFullScreenOnWeb` flag (defaults to `true`; no effect on non-web platforms). Thanks [Ortes](https://github.com/Ortes).
 * 🖱️ [#950](https://github.com/fluttercommunity/chewie/pull/950): Show click cursor on hover over Material controls and progress bar. Thanks [Ortes](https://github.com/Ortes).

--- a/lib/src/chewie_player.dart
+++ b/lib/src/chewie_player.dart
@@ -6,6 +6,7 @@ import 'package:chewie/src/models/option_item.dart';
 import 'package:chewie/src/models/options_translation.dart';
 import 'package:chewie/src/models/subtitle_model.dart';
 import 'package:chewie/src/models/subtitle_style.dart';
+import 'package:chewie/src/models/subtitle_track.dart';
 import 'package:chewie/src/notifiers/player_notifier.dart';
 import 'package:chewie/src/player_with_controls.dart';
 import 'package:flutter/foundation.dart';
@@ -344,6 +345,9 @@ class ChewieController extends ChangeNotifier {
     this.showSubtitles = false,
     this.subtitleBuilder,
     this.subtitleStyle = const SubtitleStyle(),
+    this.subtitleTracks = const <SubtitleTrack>[],
+    this.activeSubtitleTrackId,
+    this.onSubtitleTrackChanged,
     this.customControls,
     this.errorBuilder,
     this.bufferingBuilder,
@@ -399,6 +403,9 @@ class ChewieController extends ChangeNotifier {
     bool? showSubtitles,
     Widget Function(BuildContext, dynamic)? subtitleBuilder,
     SubtitleStyle? subtitleStyle,
+    List<SubtitleTrack>? subtitleTracks,
+    Object? activeSubtitleTrackId,
+    void Function(SubtitleTrack? track)? onSubtitleTrackChanged,
     Widget? customControls,
     WidgetBuilder? bufferingBuilder,
     Widget Function(BuildContext, String)? errorBuilder,
@@ -463,6 +470,10 @@ class ChewieController extends ChangeNotifier {
       subtitle: subtitle ?? this.subtitle,
       subtitleBuilder: subtitleBuilder ?? this.subtitleBuilder,
       subtitleStyle: subtitleStyle ?? this.subtitleStyle,
+      subtitleTracks: subtitleTracks ?? this.subtitleTracks,
+      activeSubtitleTrackId: activeSubtitleTrackId ?? this.activeSubtitleTrackId,
+      onSubtitleTrackChanged:
+          onSubtitleTrackChanged ?? this.onSubtitleTrackChanged,
       customControls: customControls ?? this.customControls,
       errorBuilder: errorBuilder ?? this.errorBuilder,
       bufferingBuilder: bufferingBuilder ?? this.bufferingBuilder,
@@ -548,6 +559,28 @@ class ChewieController extends ChangeNotifier {
   /// If set to `true`, subtitles will be displayed automatically when the video
   /// begins playing. If set to `false`, subtitles will be hidden by default.
   bool showSubtitles;
+
+  /// Selectable subtitle tracks shown in the options menu.
+  ///
+  /// Source-agnostic: the host populates this (e.g. from an HLS manifest) and
+  /// reacts to selection via [onSubtitleTrackChanged]. May change after the
+  /// video loads — use [setSubtitleTracks] so the controls rebuild.
+  List<SubtitleTrack> subtitleTracks;
+
+  /// Id of the currently selected track in [subtitleTracks], or `null` when
+  /// subtitles are off.
+  Object? activeSubtitleTrackId;
+
+  /// Called when the user picks a track from the menu (or `null` for "Off").
+  final void Function(SubtitleTrack? track)? onSubtitleTrackChanged;
+
+  /// The text of the cue currently on screen, for streaming sources that emit
+  /// cues over time (e.g. HLS) rather than as a static [subtitle] list. Push
+  /// updates with [setLiveSubtitle]; the controls render it when non-null.
+  final ValueNotifier<String?> liveSubtitle = ValueNotifier<String?>(null);
+
+  /// Whether any selectable subtitle tracks are available.
+  bool get hasSubtitleTracks => subtitleTracks.isNotEmpty;
 
   /// The controller for the video you want to play
   final VideoPlayerController videoPlayerController;
@@ -772,6 +805,39 @@ class ChewieController extends ChangeNotifier {
 
   void setSubtitle(List<Subtitle> newSubtitle) {
     subtitle = Subtitles(newSubtitle);
+  }
+
+  /// Replaces the selectable [subtitleTracks] and rebuilds the controls.
+  ///
+  /// Use when tracks become known only after the media loads (e.g. once an
+  /// HLS manifest is parsed).
+  void setSubtitleTracks(List<SubtitleTrack> tracks) {
+    subtitleTracks = tracks;
+    notifyListeners();
+  }
+
+  /// Selects [track] (or `null` to turn subtitles off), updating
+  /// [activeSubtitleTrackId], notifying [onSubtitleTrackChanged] and clearing
+  /// any on-screen [liveSubtitle] when turned off.
+  void selectSubtitleTrack(SubtitleTrack? track) {
+    activeSubtitleTrackId = track?.id;
+    if (track == null) {
+      liveSubtitle.value = null;
+    }
+    onSubtitleTrackChanged?.call(track);
+    notifyListeners();
+  }
+
+  /// Pushes the current cue text for streaming subtitle sources. Pass `null`
+  /// when no cue is showing.
+  void setLiveSubtitle(String? text) {
+    liveSubtitle.value = text;
+  }
+
+  @override
+  void dispose() {
+    liveSubtitle.dispose();
+    super.dispose();
   }
 }
 

--- a/lib/src/chewie_player.dart
+++ b/lib/src/chewie_player.dart
@@ -471,7 +471,8 @@ class ChewieController extends ChangeNotifier {
       subtitleBuilder: subtitleBuilder ?? this.subtitleBuilder,
       subtitleStyle: subtitleStyle ?? this.subtitleStyle,
       subtitleTracks: subtitleTracks ?? this.subtitleTracks,
-      activeSubtitleTrackId: activeSubtitleTrackId ?? this.activeSubtitleTrackId,
+      activeSubtitleTrackId:
+          activeSubtitleTrackId ?? this.activeSubtitleTrackId,
       onSubtitleTrackChanged:
           onSubtitleTrackChanged ?? this.onSubtitleTrackChanged,
       customControls: customControls ?? this.customControls,

--- a/lib/src/material/material_controls.dart
+++ b/lib/src/material/material_controls.dart
@@ -8,8 +8,10 @@ import 'package:chewie/src/helpers/utils.dart';
 import 'package:chewie/src/material/material_progress_bar.dart';
 import 'package:chewie/src/material/widgets/options_dialog.dart';
 import 'package:chewie/src/material/widgets/playback_speed_dialog.dart';
+import 'package:chewie/src/material/widgets/subtitle_track_dialog.dart';
 import 'package:chewie/src/models/option_item.dart';
 import 'package:chewie/src/models/subtitle_model.dart';
+import 'package:chewie/src/models/subtitle_track.dart';
 import 'package:chewie/src/notifiers/index.dart';
 import 'package:chewie/src/subtitle_overlay.dart';
 import 'package:flutter/material.dart';
@@ -86,17 +88,13 @@ class _MaterialControlsState extends State<MaterialControls>
               Column(
                 mainAxisAlignment: MainAxisAlignment.end,
                 children: <Widget>[
-                  if (_subtitleOn)
-                    Transform.translate(
-                      offset: Offset(
-                        0.0,
-                        notifier.hideStuff ? barHeight * 0.8 : 0.0,
-                      ),
-                      child: _buildSubtitles(
-                        context,
-                        chewieController.subtitle!,
-                      ),
+                  Transform.translate(
+                    offset: Offset(
+                      0.0,
+                      notifier.hideStuff ? barHeight * 0.8 : 0.0,
                     ),
+                    child: _buildSubtitleLayer(context),
+                  ),
                   _buildBottomBar(context),
                 ],
               ),
@@ -165,6 +163,17 @@ class _MaterialControlsState extends State<MaterialControls>
             chewieController.optionsTranslation?.playbackSpeedButtonText ??
             'Playback speed',
       ),
+      if (chewieController.hasSubtitleTracks)
+        OptionItem(
+          onTap: (context) async {
+            Navigator.pop(context);
+            await _onSubtitleTrackButtonTap();
+          },
+          iconData: Icons.subtitles_outlined,
+          title:
+              chewieController.optionsTranslation?.subtitlesButtonText ??
+              'Subtitles',
+        ),
     ];
 
     if (chewieController.additionalOptions != null &&
@@ -207,6 +216,31 @@ class _MaterialControlsState extends State<MaterialControls>
         icon: const Icon(Icons.more_vert, color: Colors.white),
       ),
     );
+  }
+
+  /// Picks the right subtitle source: a streaming [ChewieController.liveSubtitle]
+  /// (for sources like HLS that emit cues over time) when present, otherwise
+  /// the static [ChewieController.subtitle] cue list.
+  Widget _buildSubtitleLayer(BuildContext context) {
+    if (!_subtitleOn) return const SizedBox();
+
+    final usesLiveCues =
+        chewieController.hasSubtitleTracks || chewieController.subtitle == null;
+    if (usesLiveCues) {
+      return ValueListenableBuilder<String?>(
+        valueListenable: chewieController.liveSubtitle,
+        builder: (context, text, _) {
+          if (text == null || text.isEmpty) return const SizedBox();
+          return SubtitleOverlay(
+            chewieController: chewieController,
+            margin: EdgeInsets.all(marginSize),
+            text: text,
+          );
+        },
+      );
+    }
+
+    return _buildSubtitles(context, chewieController.subtitle!);
   }
 
   Widget _buildSubtitles(BuildContext context, Subtitles subtitles) {
@@ -457,8 +491,10 @@ class _MaterialControlsState extends State<MaterialControls>
   }
 
   Widget _buildSubtitleToggle() {
-    //if don't have subtitle hiden button
-    if (chewieController.subtitle?.isEmpty ?? true) {
+    // Hide the button when there's nothing to toggle: neither a static cue
+    // list nor selectable tracks.
+    final hasStaticSubtitle = chewieController.subtitle?.isNotEmpty ?? false;
+    if (!hasStaticSubtitle && !chewieController.hasSubtitleTracks) {
       return const SizedBox();
     }
     return GestureDetector(
@@ -481,9 +517,59 @@ class _MaterialControlsState extends State<MaterialControls>
   }
 
   void _onSubtitleTap() {
+    final controller = chewieController;
+    // With selectable tracks, toggling also drives the track selection so the
+    // host can start/stop producing cues.
+    if (controller.hasSubtitleTracks) {
+      if (_subtitleOn) {
+        controller.selectSubtitleTrack(null);
+        setState(() => _subtitleOn = false);
+      } else {
+        controller.selectSubtitleTrack(_activeTrackOrDefault());
+        setState(() => _subtitleOn = true);
+      }
+      return;
+    }
     setState(() {
       _subtitleOn = !_subtitleOn;
     });
+  }
+
+  SubtitleTrack? _activeTrackOrDefault() {
+    final tracks = chewieController.subtitleTracks;
+    if (tracks.isEmpty) return null;
+    final activeId = chewieController.activeSubtitleTrackId;
+    for (final track in tracks) {
+      if (track.id == activeId) return track;
+    }
+    return tracks.first;
+  }
+
+  Future<void> _onSubtitleTrackButtonTap() async {
+    _hideTimer?.cancel();
+
+    final choice = await showModalBottomSheet<SubtitleTrackChoice>(
+      context: context,
+      isScrollControlled: true,
+      useRootNavigator: chewieController.useRootNavigator,
+      builder: (context) => SubtitleTrackDialog(
+        tracks: chewieController.subtitleTracks,
+        selectedId: chewieController.activeSubtitleTrackId,
+        offLabel:
+            chewieController.optionsTranslation?.subtitlesButtonText != null
+            ? '${chewieController.optionsTranslation!.subtitlesButtonText} — off'
+            : 'Off',
+      ),
+    );
+
+    if (choice != null) {
+      chewieController.selectSubtitleTrack(choice.track);
+      setState(() => _subtitleOn = choice.track != null);
+    }
+
+    if (_latestValue.isPlaying) {
+      _startHideTimer();
+    }
   }
 
   void _cancelAndRestartTimer() {
@@ -498,8 +584,9 @@ class _MaterialControlsState extends State<MaterialControls>
 
   Future<void> _initialize() async {
     _subtitleOn =
-        chewieController.showSubtitles &&
-        (chewieController.subtitle?.isNotEmpty ?? false);
+        (chewieController.showSubtitles &&
+            (chewieController.subtitle?.isNotEmpty ?? false)) ||
+        chewieController.activeSubtitleTrackId != null;
     controller.addListener(_updateState);
 
     _updateState();

--- a/lib/src/material/material_controls.dart
+++ b/lib/src/material/material_controls.dart
@@ -113,6 +113,7 @@ class _MaterialControlsState extends State<MaterialControls>
 
   void _dispose() {
     controller.removeListener(_updateState);
+    chewieController.removeListener(_onChewieControllerChanged);
     _hideTimer?.cancel();
     _initTimer?.cancel();
     _showAfterExpandCollapseTimer?.cancel();
@@ -588,6 +589,7 @@ class _MaterialControlsState extends State<MaterialControls>
             (chewieController.subtitle?.isNotEmpty ?? false)) ||
         chewieController.activeSubtitleTrackId != null;
     controller.addListener(_updateState);
+    chewieController.addListener(_onChewieControllerChanged);
 
     _updateState();
 
@@ -713,6 +715,17 @@ class _MaterialControlsState extends State<MaterialControls>
       _latestValue = controller.value;
       _subtitlesPosition = controller.value.position;
     });
+  }
+
+  // Keeps the subtitle toggle in sync when the host drives track selection
+  // programmatically (e.g. selectSubtitleTrack / setSubtitleTracks) rather than
+  // through the UI: those notify [chewieController], not the video controller.
+  void _onChewieControllerChanged() {
+    if (!mounted || !chewieController.hasSubtitleTracks) return;
+    final bool shouldBeOn = chewieController.activeSubtitleTrackId != null;
+    if (shouldBeOn != _subtitleOn) {
+      setState(() => _subtitleOn = shouldBeOn);
+    }
   }
 
   Widget _buildProgressBar() {

--- a/lib/src/material/material_desktop_controls.dart
+++ b/lib/src/material/material_desktop_controls.dart
@@ -8,8 +8,10 @@ import 'package:chewie/src/helpers/utils.dart';
 import 'package:chewie/src/material/material_progress_bar.dart';
 import 'package:chewie/src/material/widgets/options_dialog.dart';
 import 'package:chewie/src/material/widgets/playback_speed_dialog.dart';
+import 'package:chewie/src/material/widgets/subtitle_track_dialog.dart';
 import 'package:chewie/src/models/option_item.dart';
 import 'package:chewie/src/models/subtitle_model.dart';
+import 'package:chewie/src/models/subtitle_track.dart';
 import 'package:chewie/src/notifiers/index.dart';
 import 'package:chewie/src/subtitle_overlay.dart';
 import 'package:flutter/material.dart';
@@ -113,17 +115,13 @@ class _MaterialDesktopControlsState extends State<MaterialDesktopControls>
                 Column(
                   mainAxisAlignment: MainAxisAlignment.end,
                   children: <Widget>[
-                    if (_subtitleOn)
-                      Transform.translate(
-                        offset: Offset(
-                          0.0,
-                          notifier.hideStuff ? barHeight * 0.8 : 0.0,
-                        ),
-                        child: _buildSubtitles(
-                          context,
-                          chewieController.subtitle!,
-                        ),
+                    Transform.translate(
+                      offset: Offset(
+                        0.0,
+                        notifier.hideStuff ? barHeight * 0.8 : 0.0,
                       ),
+                      child: _buildSubtitleLayer(context),
+                    ),
                     _buildBottomBar(context),
                   ],
                 ),
@@ -183,6 +181,17 @@ class _MaterialDesktopControlsState extends State<MaterialDesktopControls>
             chewieController.optionsTranslation?.playbackSpeedButtonText ??
             'Playback speed',
       ),
+      if (chewieController.hasSubtitleTracks)
+        OptionItem(
+          onTap: (context) async {
+            Navigator.pop(context);
+            await _onSubtitleTrackButtonTap();
+          },
+          iconData: Icons.subtitles_outlined,
+          title:
+              chewieController.optionsTranslation?.subtitlesButtonText ??
+              'Subtitles',
+        ),
     ];
 
     if (chewieController.additionalOptions != null &&
@@ -220,6 +229,31 @@ class _MaterialDesktopControlsState extends State<MaterialDesktopControls>
         icon: Icon(icon ?? Icons.more_vert, color: Colors.white),
       ),
     );
+  }
+
+  /// Picks the right subtitle source: a streaming [ChewieController.liveSubtitle]
+  /// (for sources like HLS that emit cues over time) when present, otherwise
+  /// the static [ChewieController.subtitle] cue list.
+  Widget _buildSubtitleLayer(BuildContext context) {
+    if (!_subtitleOn) return const SizedBox();
+
+    final usesLiveCues =
+        chewieController.hasSubtitleTracks || chewieController.subtitle == null;
+    if (usesLiveCues) {
+      return ValueListenableBuilder<String?>(
+        valueListenable: chewieController.liveSubtitle,
+        builder: (context, text, _) {
+          if (text == null || text.isEmpty) return const SizedBox();
+          return SubtitleOverlay(
+            chewieController: chewieController,
+            margin: EdgeInsets.all(marginSize),
+            text: text,
+          );
+        },
+      );
+    }
+
+    return _buildSubtitles(context, chewieController.subtitle!);
   }
 
   Widget _buildSubtitles(BuildContext context, Subtitles subtitles) {
@@ -268,8 +302,8 @@ class _MaterialDesktopControlsState extends State<MaterialDesktopControls>
                       _buildPosition(iconColor),
                     const Spacer(),
                     if (chewieController.showControls &&
-                        chewieController.subtitle != null &&
-                        chewieController.subtitle!.isNotEmpty)
+                        ((chewieController.subtitle?.isNotEmpty ?? false) ||
+                            chewieController.hasSubtitleTracks))
                       _buildSubtitleToggle(icon: Icons.subtitles),
                     if (chewieController.showOptions)
                       _buildOptionsButton(icon: Icons.settings),
@@ -446,9 +480,55 @@ class _MaterialDesktopControlsState extends State<MaterialDesktopControls>
   }
 
   void _onSubtitleTap() {
+    final controller = chewieController;
+    // With selectable tracks, toggling also drives the track selection so the
+    // host can start/stop producing cues.
+    if (controller.hasSubtitleTracks) {
+      if (_subtitleOn) {
+        controller.selectSubtitleTrack(null);
+        setState(() => _subtitleOn = false);
+      } else {
+        controller.selectSubtitleTrack(_activeTrackOrDefault());
+        setState(() => _subtitleOn = true);
+      }
+      return;
+    }
     setState(() {
       _subtitleOn = !_subtitleOn;
     });
+  }
+
+  SubtitleTrack? _activeTrackOrDefault() {
+    final tracks = chewieController.subtitleTracks;
+    if (tracks.isEmpty) return null;
+    final activeId = chewieController.activeSubtitleTrackId;
+    for (final track in tracks) {
+      if (track.id == activeId) return track;
+    }
+    return tracks.first;
+  }
+
+  Future<void> _onSubtitleTrackButtonTap() async {
+    _hideTimer?.cancel();
+
+    final choice = await showModalBottomSheet<SubtitleTrackChoice>(
+      context: context,
+      isScrollControlled: true,
+      useRootNavigator: chewieController.useRootNavigator,
+      builder: (context) => SubtitleTrackDialog(
+        tracks: chewieController.subtitleTracks,
+        selectedId: chewieController.activeSubtitleTrackId,
+      ),
+    );
+
+    if (choice != null) {
+      chewieController.selectSubtitleTrack(choice.track);
+      setState(() => _subtitleOn = choice.track != null);
+    }
+
+    if (_latestValue.isPlaying) {
+      _startHideTimer();
+    }
   }
 
   void _cancelAndRestartTimer() {
@@ -463,8 +543,9 @@ class _MaterialDesktopControlsState extends State<MaterialDesktopControls>
 
   Future<void> _initialize() async {
     _subtitleOn =
-        chewieController.showSubtitles &&
-        (chewieController.subtitle?.isNotEmpty ?? false);
+        (chewieController.showSubtitles &&
+            (chewieController.subtitle?.isNotEmpty ?? false)) ||
+        chewieController.activeSubtitleTrackId != null;
     controller.addListener(_updateState);
 
     _updateState();

--- a/lib/src/material/material_desktop_controls.dart
+++ b/lib/src/material/material_desktop_controls.dart
@@ -518,6 +518,10 @@ class _MaterialDesktopControlsState extends State<MaterialDesktopControls>
       builder: (context) => SubtitleTrackDialog(
         tracks: chewieController.subtitleTracks,
         selectedId: chewieController.activeSubtitleTrackId,
+        offLabel:
+            chewieController.optionsTranslation?.subtitlesButtonText != null
+            ? '${chewieController.optionsTranslation!.subtitlesButtonText} — off'
+            : 'Off',
       ),
     );
 

--- a/lib/src/material/material_desktop_controls.dart
+++ b/lib/src/material/material_desktop_controls.dart
@@ -142,6 +142,7 @@ class _MaterialDesktopControlsState extends State<MaterialDesktopControls>
 
   void _dispose() {
     controller.removeListener(_updateState);
+    chewieController.removeListener(_onChewieControllerChanged);
     _hideTimer?.cancel();
     _initTimer?.cancel();
     _showAfterExpandCollapseTimer?.cancel();
@@ -551,6 +552,7 @@ class _MaterialDesktopControlsState extends State<MaterialDesktopControls>
             (chewieController.subtitle?.isNotEmpty ?? false)) ||
         chewieController.activeSubtitleTrackId != null;
     controller.addListener(_updateState);
+    chewieController.addListener(_onChewieControllerChanged);
 
     _updateState();
 
@@ -650,6 +652,17 @@ class _MaterialDesktopControlsState extends State<MaterialDesktopControls>
       _latestValue = controller.value;
       _subtitlesPosition = controller.value.position;
     });
+  }
+
+  // Keeps the subtitle toggle in sync when the host drives track selection
+  // programmatically (e.g. selectSubtitleTrack / setSubtitleTracks) rather than
+  // through the UI: those notify [chewieController], not the video controller.
+  void _onChewieControllerChanged() {
+    if (!mounted || !chewieController.hasSubtitleTracks) return;
+    final bool shouldBeOn = chewieController.activeSubtitleTrackId != null;
+    if (shouldBeOn != _subtitleOn) {
+      setState(() => _subtitleOn = shouldBeOn);
+    }
   }
 
   void _seekBackward() {

--- a/lib/src/material/widgets/subtitle_track_dialog.dart
+++ b/lib/src/material/widgets/subtitle_track_dialog.dart
@@ -1,0 +1,83 @@
+import 'package:chewie/src/models/subtitle_track.dart';
+import 'package:flutter/material.dart';
+
+/// The user's pick from a [SubtitleTrackDialog].
+///
+/// Wrapping the track lets callers tell "the user chose Off" ([track] is
+/// `null`) apart from "the dialog was dismissed" (the dialog pops `null`).
+class SubtitleTrackChoice {
+  const SubtitleTrackChoice(this.track);
+
+  /// The selected track, or `null` when the user picked "Off".
+  final SubtitleTrack? track;
+}
+
+/// Lets the user pick one of the available [SubtitleTrack]s, or turn subtitles
+/// off. Pops with a [SubtitleTrackChoice], or `null` when dismissed.
+class SubtitleTrackDialog extends StatelessWidget {
+  const SubtitleTrackDialog({
+    super.key,
+    required List<SubtitleTrack> tracks,
+    required Object? selectedId,
+    this.offLabel = 'Off',
+  }) : _tracks = tracks,
+       _selectedId = selectedId;
+
+  final List<SubtitleTrack> _tracks;
+  final Object? _selectedId;
+  final String offLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    final Color selectedColor = Theme.of(context).primaryColor;
+
+    Widget tile({
+      required bool selected,
+      required String label,
+      String? trailing,
+      required VoidCallback onTap,
+    }) {
+      return ListTile(
+        dense: true,
+        selected: selected,
+        onTap: onTap,
+        title: Row(
+          children: [
+            if (selected)
+              Icon(Icons.check, size: 20.0, color: selectedColor)
+            else
+              const SizedBox(width: 20.0),
+            const SizedBox(width: 16.0),
+            Expanded(child: Text(label)),
+            if (trailing != null)
+              Text(
+                trailing,
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+          ],
+        ),
+      );
+    }
+
+    return ListView(
+      shrinkWrap: true,
+      physics: const ScrollPhysics(),
+      children: [
+        tile(
+          selected: _selectedId == null,
+          label: offLabel,
+          onTap: () =>
+              Navigator.of(context).pop(const SubtitleTrackChoice(null)),
+        ),
+        for (final track in _tracks)
+          tile(
+            selected: track.id == _selectedId,
+            label: track.label,
+            trailing: track.language,
+            onTap: () =>
+                Navigator.of(context).pop(SubtitleTrackChoice(track)),
+          ),
+      ],
+    );
+  }
+}

--- a/lib/src/material/widgets/subtitle_track_dialog.dart
+++ b/lib/src/material/widgets/subtitle_track_dialog.dart
@@ -50,10 +50,7 @@ class SubtitleTrackDialog extends StatelessWidget {
             const SizedBox(width: 16.0),
             Expanded(child: Text(label)),
             if (trailing != null)
-              Text(
-                trailing,
-                style: Theme.of(context).textTheme.bodySmall,
-              ),
+              Text(trailing, style: Theme.of(context).textTheme.bodySmall),
           ],
         ),
       );
@@ -74,8 +71,7 @@ class SubtitleTrackDialog extends StatelessWidget {
             selected: track.id == _selectedId,
             label: track.label,
             trailing: track.language,
-            onTap: () =>
-                Navigator.of(context).pop(SubtitleTrackChoice(track)),
+            onTap: () => Navigator.of(context).pop(SubtitleTrackChoice(track)),
           ),
       ],
     );

--- a/lib/src/models/index.dart
+++ b/lib/src/models/index.dart
@@ -2,3 +2,4 @@ export 'option_item.dart';
 export 'options_translation.dart';
 export 'subtitle_model.dart';
 export 'subtitle_style.dart';
+export 'subtitle_track.dart';

--- a/lib/src/models/subtitle_track.dart
+++ b/lib/src/models/subtitle_track.dart
@@ -1,0 +1,38 @@
+/// A selectable subtitle track surfaced in the player's options menu.
+///
+/// This is intentionally decoupled from any particular source (HLS, embedded,
+/// sidecar files...). The host supplies the tracks and reacts to the user's
+/// selection through [ChewieController.onSubtitleTrackChanged]; how cues are
+/// produced and fed back (e.g. via [ChewieController.setLiveSubtitle] for a
+/// streaming source, or via [ChewieController.setSubtitle] for a parsed cue
+/// list) is left to the host.
+class SubtitleTrack {
+  const SubtitleTrack({
+    required this.id,
+    required this.label,
+    this.language,
+  });
+
+  /// Opaque identifier the host uses to recognise the track on selection.
+  final Object id;
+
+  /// Human-readable name shown in the menu.
+  final String label;
+
+  /// Optional BCP-47 language tag, shown as a hint next to [label].
+  final String? language;
+
+  @override
+  bool operator ==(Object other) =>
+      other is SubtitleTrack &&
+      other.id == id &&
+      other.label == label &&
+      other.language == language;
+
+  @override
+  int get hashCode => Object.hash(id, label, language);
+
+  @override
+  String toString() =>
+      'SubtitleTrack(id: $id, label: $label, language: $language)';
+}

--- a/lib/src/models/subtitle_track.dart
+++ b/lib/src/models/subtitle_track.dart
@@ -7,11 +7,7 @@
 /// streaming source, or via [ChewieController.setSubtitle] for a parsed cue
 /// list) is left to the host.
 class SubtitleTrack {
-  const SubtitleTrack({
-    required this.id,
-    required this.label,
-    this.language,
-  });
+  const SubtitleTrack({required this.id, required this.label, this.language});
 
   /// Opaque identifier the host uses to recognise the track on selection.
   final Object id;

--- a/test/subtitle_track_dialog_test.dart
+++ b/test/subtitle_track_dialog_test.dart
@@ -1,0 +1,145 @@
+import 'dart:async';
+
+import 'package:chewie/src/material/widgets/subtitle_track_dialog.dart';
+import 'package:chewie/src/models/subtitle_track.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const _tracks = <SubtitleTrack>[
+  SubtitleTrack(id: 'en', label: 'English', language: 'en'),
+  SubtitleTrack(id: 'fr', label: 'French', language: 'fr'),
+];
+
+Future<SubtitleTrackChoice?> _openDialog(
+  WidgetTester tester, {
+  Object? selectedId,
+  String offLabel = 'Off',
+}) async {
+  SubtitleTrackChoice? result;
+  late BuildContext sheetContext;
+
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: Builder(
+          builder: (context) {
+            sheetContext = context;
+            return const SizedBox();
+          },
+        ),
+      ),
+    ),
+  );
+
+  unawaited(
+    showModalBottomSheet<SubtitleTrackChoice>(
+      context: sheetContext,
+      builder: (context) => SubtitleTrackDialog(
+        tracks: _tracks,
+        selectedId: selectedId,
+        offLabel: offLabel,
+      ),
+    ).then((value) => result = value),
+  );
+
+  await tester.pumpAndSettle();
+  return result;
+}
+
+void main() {
+  testWidgets('renders the Off entry plus one tile per track', (tester) async {
+    await _openDialog(tester, selectedId: 'en');
+
+    expect(find.text('Off'), findsOneWidget);
+    expect(find.text('English'), findsOneWidget);
+    expect(find.text('French'), findsOneWidget);
+    // The language hint is shown as trailing text.
+    expect(find.text('en'), findsOneWidget);
+    expect(find.text('fr'), findsOneWidget);
+    // The selected track shows a check icon.
+    expect(find.byIcon(Icons.check), findsOneWidget);
+  });
+
+  testWidgets('honours a custom off label', (tester) async {
+    await _openDialog(tester, selectedId: null, offLabel: 'Subtitles — off');
+    expect(find.text('Subtitles — off'), findsOneWidget);
+    // With nothing selected, the Off entry carries the check.
+    expect(find.byIcon(Icons.check), findsOneWidget);
+  });
+
+  testWidgets('tapping a track pops a choice carrying that track', (
+    tester,
+  ) async {
+    SubtitleTrackChoice? choice;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => Center(
+              child: ElevatedButton(
+                onPressed: () async {
+                  choice = await showModalBottomSheet<SubtitleTrackChoice>(
+                    context: context,
+                    builder: (context) => const SubtitleTrackDialog(
+                      tracks: _tracks,
+                      selectedId: 'en',
+                    ),
+                  );
+                },
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('French'));
+    await tester.pumpAndSettle();
+
+    expect(choice, isNotNull);
+    expect(choice!.track, isNotNull);
+    expect(choice!.track!.id, 'fr');
+  });
+
+  testWidgets('tapping Off pops a choice with a null track', (tester) async {
+    SubtitleTrackChoice? choice;
+    var popped = false;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => Center(
+              child: ElevatedButton(
+                onPressed: () async {
+                  choice = await showModalBottomSheet<SubtitleTrackChoice>(
+                    context: context,
+                    builder: (context) => const SubtitleTrackDialog(
+                      tracks: _tracks,
+                      selectedId: 'en',
+                    ),
+                  );
+                  popped = true;
+                },
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Off'));
+    await tester.pumpAndSettle();
+
+    expect(popped, isTrue);
+    expect(choice, isNotNull);
+    expect(choice!.track, isNull);
+  });
+}

--- a/test/subtitle_track_test.dart
+++ b/test/subtitle_track_test.dart
@@ -1,0 +1,58 @@
+import 'package:chewie/src/models/subtitle_track.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('SubtitleTrack', () {
+    test('exposes the values it was constructed with', () {
+      const track = SubtitleTrack(id: 'en', label: 'English', language: 'en');
+      expect(track.id, 'en');
+      expect(track.label, 'English');
+      expect(track.language, 'en');
+    });
+
+    test('language is optional', () {
+      const track = SubtitleTrack(id: 1, label: 'Track 1');
+      expect(track.language, isNull);
+    });
+
+    test('value equality compares id, label and language', () {
+      const a = SubtitleTrack(id: 'en', label: 'English', language: 'en');
+      const b = SubtitleTrack(id: 'en', label: 'English', language: 'en');
+      const differentId = SubtitleTrack(
+        id: 'fr',
+        label: 'English',
+        language: 'en',
+      );
+      const differentLabel = SubtitleTrack(
+        id: 'en',
+        label: 'Anglais',
+        language: 'en',
+      );
+      const differentLanguage = SubtitleTrack(
+        id: 'en',
+        label: 'English',
+        language: 'gb',
+      );
+
+      expect(a, equals(b));
+      expect(a == differentId, isFalse);
+      expect(a == differentLabel, isFalse);
+      expect(a == differentLanguage, isFalse);
+      expect(a == Object(), isFalse);
+    });
+
+    test('hashCode is consistent with equality', () {
+      const a = SubtitleTrack(id: 'en', label: 'English', language: 'en');
+      const b = SubtitleTrack(id: 'en', label: 'English', language: 'en');
+      expect(a.hashCode, equals(b.hashCode));
+    });
+
+    test('toString includes the fields', () {
+      const track = SubtitleTrack(id: 'en', label: 'English', language: 'en');
+      expect(
+        track.toString(),
+        'SubtitleTrack(id: en, label: English, language: en)',
+      );
+    });
+  });
+}

--- a/test/subtitle_tracks_test.dart
+++ b/test/subtitle_tracks_test.dart
@@ -201,6 +201,35 @@ void main() {
         expect(selections.last, _tracks[0]);
       });
 
+      testWidgets('programmatic selection keeps the toggle in sync', (
+        tester,
+      ) async {
+        final controller = _controller(
+          tracks: _tracks,
+          activeSubtitleTrackId: 'en',
+          customControls: controls(),
+        );
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(body: Chewie(controller: controller)),
+          ),
+        );
+        await reveal(tester);
+
+        // Starts on (an active track was provided).
+        expect(find.byIcon(toggleOnIcon), findsOneWidget);
+
+        // Host turns subtitles off without touching the UI.
+        controller.selectSubtitleTrack(null);
+        await tester.pump();
+        expect(find.byIcon(toggleOffIcon), findsOneWidget);
+
+        // Host selects a track again -> the toggle reflects it.
+        controller.selectSubtitleTrack(_tracks[1]);
+        await tester.pump();
+        expect(find.byIcon(toggleOnIcon), findsOneWidget);
+      });
+
       testWidgets('the options menu opens the track picker', (tester) async {
         final selections = <SubtitleTrack?>[];
         final controller = _controller(

--- a/test/subtitle_tracks_test.dart
+++ b/test/subtitle_tracks_test.dart
@@ -1,0 +1,309 @@
+import 'package:chewie/chewie.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:video_player/video_player.dart';
+
+final Uri _src = Uri.parse(
+  'https://assets.mixkit.co/videos/preview/mixkit-spinning-around-the-earth-29351-large.mp4',
+);
+
+const _tracks = <SubtitleTrack>[
+  SubtitleTrack(id: 'en', label: 'English', language: 'en'),
+  SubtitleTrack(id: 'fr', label: 'French', language: 'fr'),
+];
+
+ChewieController _controller({
+  List<SubtitleTrack> tracks = const <SubtitleTrack>[],
+  Object? activeSubtitleTrackId,
+  void Function(SubtitleTrack?)? onSubtitleTrackChanged,
+  Widget Function(BuildContext, dynamic)? subtitleBuilder,
+  Subtitles? subtitle,
+  bool showSubtitles = false,
+  OptionsTranslation? optionsTranslation,
+  Widget? customControls,
+}) {
+  return ChewieController(
+    videoPlayerController: VideoPlayerController.networkUrl(_src),
+    autoPlay: false,
+    looping: false,
+    subtitleTracks: tracks,
+    activeSubtitleTrackId: activeSubtitleTrackId,
+    onSubtitleTrackChanged: onSubtitleTrackChanged,
+    subtitleBuilder: subtitleBuilder,
+    subtitle: subtitle,
+    showSubtitles: showSubtitles,
+    optionsTranslation: optionsTranslation,
+    customControls: customControls,
+  );
+}
+
+void main() {
+  group('ChewieController subtitle tracks', () {
+    test('hasSubtitleTracks reflects the track list', () {
+      final controller = _controller();
+      expect(controller.hasSubtitleTracks, isFalse);
+
+      var notified = 0;
+      controller.addListener(() => notified++);
+      controller.setSubtitleTracks(_tracks);
+
+      expect(controller.hasSubtitleTracks, isTrue);
+      expect(controller.subtitleTracks, _tracks);
+      expect(notified, 1);
+    });
+
+    test('selectSubtitleTrack sets the active id and notifies the host', () {
+      SubtitleTrack? received;
+      var called = 0;
+      final controller = _controller(
+        tracks: _tracks,
+        onSubtitleTrackChanged: (track) {
+          received = track;
+          called++;
+        },
+      );
+
+      controller.selectSubtitleTrack(_tracks[1]);
+      expect(controller.activeSubtitleTrackId, 'fr');
+      expect(called, 1);
+      expect(received, _tracks[1]);
+    });
+
+    test('selecting the null track clears the live cue', () {
+      final controller = _controller(tracks: _tracks);
+      controller.setLiveSubtitle('a cue on screen');
+      expect(controller.liveSubtitle.value, 'a cue on screen');
+
+      controller.selectSubtitleTrack(null);
+      expect(controller.activeSubtitleTrackId, isNull);
+      expect(controller.liveSubtitle.value, isNull);
+    });
+
+    test('setLiveSubtitle pushes cue text through the notifier', () {
+      final controller = _controller(tracks: _tracks);
+      controller.setLiveSubtitle('hello');
+      expect(controller.liveSubtitle.value, 'hello');
+      controller.setLiveSubtitle(null);
+      expect(controller.liveSubtitle.value, isNull);
+    });
+
+    test('copyWith carries the subtitle-track fields', () {
+      onChanged(SubtitleTrack? _) {}
+      final controller = _controller();
+      final copy = controller.copyWith(
+        subtitleTracks: _tracks,
+        activeSubtitleTrackId: 'fr',
+        onSubtitleTrackChanged: onChanged,
+      );
+
+      expect(copy.subtitleTracks, _tracks);
+      expect(copy.activeSubtitleTrackId, 'fr');
+      expect(copy.onSubtitleTrackChanged, same(onChanged));
+    });
+
+    test('copyWith without subtitle args preserves the originals', () {
+      onChanged(SubtitleTrack? _) {}
+      final controller = _controller(
+        tracks: _tracks,
+        activeSubtitleTrackId: 'en',
+        onSubtitleTrackChanged: onChanged,
+      );
+      final copy = controller.copyWith();
+
+      expect(copy.subtitleTracks, _tracks);
+      expect(copy.activeSubtitleTrackId, 'en');
+      expect(copy.onSubtitleTrackChanged, same(onChanged));
+    });
+
+    test('dispose releases the live-subtitle notifier', () {
+      final controller = _controller(tracks: _tracks);
+      controller.dispose();
+      // Touching a disposed ValueNotifier throws in debug builds.
+      expect(
+        () => controller.liveSubtitle.addListener(() {}),
+        throwsFlutterError,
+      );
+    });
+  });
+
+  // Reveal the controls overlay: showControlsOnInitialize flips hideStuff to
+  // false after ~200ms, which lifts the AbsorbPointer so taps land.
+  Future<void> reveal(WidgetTester tester) async {
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+  }
+
+  for (final variant in <String>['material', 'desktop']) {
+    final isMaterial = variant == 'material';
+    Widget controls() =>
+        isMaterial ? const MaterialControls() : const MaterialDesktopControls();
+    // Material swaps the toggle icon with state; desktop keeps a fixed icon.
+    final toggleOnIcon = isMaterial ? Icons.closed_caption : Icons.subtitles;
+    final toggleOffIcon = isMaterial
+        ? Icons.closed_caption_off_outlined
+        : Icons.subtitles;
+    final optionsIcon = isMaterial ? Icons.more_vert : Icons.settings;
+
+    group('$variant controls subtitle UI', () {
+      testWidgets('shows the toggle and live cue when a track is active', (
+        tester,
+      ) async {
+        final controller = _controller(
+          tracks: _tracks,
+          activeSubtitleTrackId: 'en',
+          customControls: controls(),
+        );
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(body: Chewie(controller: controller)),
+          ),
+        );
+        await reveal(tester);
+
+        // Active subtitles => the toggle is shown in its "on" state.
+        expect(find.byIcon(toggleOnIcon), findsOneWidget);
+
+        controller.setLiveSubtitle('Live cue text');
+        await tester.pump();
+        expect(find.text('Live cue text'), findsOneWidget);
+
+        // Empty cue text renders nothing.
+        controller.setLiveSubtitle('');
+        await tester.pump();
+        expect(find.text(''), findsNothing);
+      });
+
+      testWidgets('tapping the toggle drives track selection', (tester) async {
+        final selections = <SubtitleTrack?>[];
+        final controller = _controller(
+          tracks: _tracks,
+          activeSubtitleTrackId: 'en',
+          onSubtitleTrackChanged: selections.add,
+          customControls: controls(),
+        );
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(body: Chewie(controller: controller)),
+          ),
+        );
+        await reveal(tester);
+
+        // Starts on -> tapping turns it off (null track).
+        await tester.tap(find.byIcon(toggleOnIcon));
+        await tester.pump();
+        expect(selections.last, isNull);
+        expect(controller.activeSubtitleTrackId, isNull);
+        expect(find.byIcon(toggleOffIcon), findsOneWidget);
+
+        // Tapping again turns it back on, defaulting to the active track.
+        await tester.tap(find.byIcon(toggleOffIcon));
+        await tester.pump();
+        expect(selections.last, _tracks[0]);
+      });
+
+      testWidgets('the options menu opens the track picker', (tester) async {
+        final selections = <SubtitleTrack?>[];
+        final controller = _controller(
+          tracks: _tracks,
+          onSubtitleTrackChanged: selections.add,
+          customControls: controls(),
+        );
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(body: Chewie(controller: controller)),
+          ),
+        );
+        await reveal(tester);
+
+        await tester.tap(find.byIcon(optionsIcon));
+        await tester.pumpAndSettle();
+        expect(find.text('Subtitles'), findsOneWidget);
+
+        await tester.tap(find.text('Subtitles'));
+        await tester.pumpAndSettle();
+
+        // Track picker is open: Off + the two tracks.
+        expect(find.text('Off'), findsOneWidget);
+        await tester.tap(find.text('French'));
+        await tester.pumpAndSettle();
+
+        expect(selections.last, _tracks[1]);
+        expect(controller.activeSubtitleTrackId, 'fr');
+      });
+
+      testWidgets('the picker uses the translated off label', (tester) async {
+        final controller = _controller(
+          tracks: _tracks,
+          optionsTranslation: OptionsTranslation(
+            subtitlesButtonText: 'Captions',
+          ),
+          customControls: controls(),
+        );
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(body: Chewie(controller: controller)),
+          ),
+        );
+        await reveal(tester);
+
+        await tester.tap(find.byIcon(optionsIcon));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('Captions'));
+        await tester.pumpAndSettle();
+
+        // Material threads the translated label into the picker's "off" entry;
+        // the desktop variant always uses the default "Off".
+        expect(
+          find.text(isMaterial ? 'Captions — off' : 'Off'),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets('renders a static subtitle cue when no tracks exist', (
+        tester,
+      ) async {
+        final controller = _controller(
+          showSubtitles: true,
+          subtitle: Subtitles([
+            Subtitle(
+              index: 0,
+              start: Duration.zero,
+              end: const Duration(hours: 1),
+              text: 'Static cue',
+            ),
+          ]),
+          customControls: controls(),
+        );
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(body: Chewie(controller: controller)),
+          ),
+        );
+        await reveal(tester);
+
+        expect(find.text('Static cue'), findsOneWidget);
+      });
+
+      testWidgets('a custom subtitleBuilder renders the live cue', (
+        tester,
+      ) async {
+        final controller = _controller(
+          tracks: _tracks,
+          activeSubtitleTrackId: 'en',
+          subtitleBuilder: (context, text) => Text('built:$text'),
+          customControls: controls(),
+        );
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(body: Chewie(controller: controller)),
+          ),
+        );
+        await reveal(tester);
+
+        controller.setLiveSubtitle('cue');
+        await tester.pump();
+        expect(find.text('built:cue'), findsOneWidget);
+      });
+    });
+  }
+}

--- a/test/subtitle_tracks_test.dart
+++ b/test/subtitle_tracks_test.dart
@@ -251,12 +251,9 @@ void main() {
         await tester.tap(find.text('Captions'));
         await tester.pumpAndSettle();
 
-        // Material threads the translated label into the picker's "off" entry;
-        // the desktop variant always uses the default "Off".
-        expect(
-          find.text(isMaterial ? 'Captions — off' : 'Off'),
-          findsOneWidget,
-        );
+        // Both variants thread the translated label into the picker's "off"
+        // entry.
+        expect(find.text('Captions — off'), findsOneWidget);
       });
 
       testWidgets('renders a static subtitle cue when no tracks exist', (


### PR DESCRIPTION
## Motivation

Streaming sources (notably HLS) expose multiple **subtitle renditions** in their manifest, but Chewie currently has no UI to let the user pick one. This adds a source-agnostic subtitle-track picker to the Material controls.

## What this adds

- A track picker in the options menu (plus an **Off** entry) that appears only when `subtitleTracks` is non-empty.
- Support for streaming cues that arrive over time (via `setLiveSubtitle`), alongside the existing static `subtitle` cue list.

The widget is **source-agnostic**: the host populates the track list and reacts to selection; Chewie never assumes HLS or any particular backend.

## API (all opt-in — defaults preserve current behavior)

`ChewieController`:
- `List<SubtitleTrack> subtitleTracks` — selectable tracks (default empty).
- `Object? activeSubtitleTrackId` — currently selected id (`null` = Off).
- `void Function(SubtitleTrack?)? onSubtitleTrackChanged` — selection callback.
- `setSubtitleTracks()` / `selectSubtitleTrack()` — for tracks known only after load.
- `setLiveSubtitle(String?)` + `ValueNotifier<String?> liveSubtitle` — push current cue text for streaming sources.
- `bool get hasSubtitleTracks` — gates the menu entry.

New: `SubtitleTrack` model and `SubtitleTrackDialog` bottom sheet.

## Backwards compatibility

Fully backwards compatible — every field is optional and defaults to the current behavior. No menu entry appears unless the host provides tracks.

## Testing

- `dart analyze` — no issues.
- In production use in an HLS web player (subtitle tracks parsed from the manifest, cues pushed via `setLiveSubtitle`).

Independent of the audio-track PR (#949) — single commit, based on `master`.