### PR TITLE
feat: multi-track audio selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [Unreleased]
+* 🔊 [#949](https://github.com/fluttercommunity/chewie/pull/949): Add source-agnostic multi-track audio selection to the Material controls, via the new `AudioTrack` model and `ChewieController.audioTracks` / `activeAudioTrackId` / `onAudioTrackChanged`. The picker only appears when more than one track is provided. Thanks [Ortes](https://github.com/Ortes).
+
 ## [1.15.0]
 * 🌐 [#946](https://github.com/fluttercommunity/chewie/pull/946): Web: enter the browser's native (OS-level) fullscreen via the Fullscreen API instead of only expanding the Flutter view inside the browser window. Pressing Escape to leave browser fullscreen also exits Chewie's fullscreen. Controlled by the new `ChewieController.useNativeFullScreenOnWeb` flag (defaults to `true`; no effect on non-web platforms). Thanks [Ortes](https://github.com/Ortes).
 * 🖱️ [#950](https://github.com/fluttercommunity/chewie/pull/950): Show click cursor on hover over Material controls and progress bar. Thanks [Ortes](https://github.com/Ortes).

--- a/lib/src/chewie_player.dart
+++ b/lib/src/chewie_player.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:chewie/src/chewie_progress_colors.dart';
 import 'web_fullscreen.dart';
+import 'package:chewie/src/models/audio_track.dart';
 import 'package:chewie/src/models/option_item.dart';
 import 'package:chewie/src/models/options_translation.dart';
 import 'package:chewie/src/models/subtitle_model.dart';
@@ -344,6 +345,9 @@ class ChewieController extends ChangeNotifier {
     this.showSubtitles = false,
     this.subtitleBuilder,
     this.subtitleStyle = const SubtitleStyle(),
+    this.audioTracks = const <AudioTrack>[],
+    this.activeAudioTrackId,
+    this.onAudioTrackChanged,
     this.customControls,
     this.errorBuilder,
     this.bufferingBuilder,
@@ -399,6 +403,9 @@ class ChewieController extends ChangeNotifier {
     bool? showSubtitles,
     Widget Function(BuildContext, dynamic)? subtitleBuilder,
     SubtitleStyle? subtitleStyle,
+    List<AudioTrack>? audioTracks,
+    Object? activeAudioTrackId,
+    void Function(AudioTrack track)? onAudioTrackChanged,
     Widget? customControls,
     WidgetBuilder? bufferingBuilder,
     Widget Function(BuildContext, String)? errorBuilder,
@@ -463,6 +470,9 @@ class ChewieController extends ChangeNotifier {
       subtitle: subtitle ?? this.subtitle,
       subtitleBuilder: subtitleBuilder ?? this.subtitleBuilder,
       subtitleStyle: subtitleStyle ?? this.subtitleStyle,
+      audioTracks: audioTracks ?? this.audioTracks,
+      activeAudioTrackId: activeAudioTrackId ?? this.activeAudioTrackId,
+      onAudioTrackChanged: onAudioTrackChanged ?? this.onAudioTrackChanged,
       customControls: customControls ?? this.customControls,
       errorBuilder: errorBuilder ?? this.errorBuilder,
       bufferingBuilder: bufferingBuilder ?? this.bufferingBuilder,
@@ -548,6 +558,24 @@ class ChewieController extends ChangeNotifier {
   /// If set to `true`, subtitles will be displayed automatically when the video
   /// begins playing. If set to `false`, subtitles will be hidden by default.
   bool showSubtitles;
+
+  /// Selectable audio tracks shown in the options menu.
+  ///
+  /// Source-agnostic: the host populates this (e.g. from an HLS manifest) and
+  /// reacts to selection via [onAudioTrackChanged]. May change after the video
+  /// loads — use [setAudioTracks] so the controls rebuild. Unlike subtitles,
+  /// audio is never "off": one track is always active.
+  List<AudioTrack> audioTracks;
+
+  /// Id of the currently selected track in [audioTracks].
+  Object? activeAudioTrackId;
+
+  /// Called when the user picks an audio track from the menu.
+  final void Function(AudioTrack track)? onAudioTrackChanged;
+
+  /// Whether more than one selectable audio track is available (a single track
+  /// offers nothing to choose, so the menu entry stays hidden).
+  bool get hasAudioTracks => audioTracks.length > 1;
 
   /// The controller for the video you want to play
   final VideoPlayerController videoPlayerController;
@@ -772,6 +800,23 @@ class ChewieController extends ChangeNotifier {
 
   void setSubtitle(List<Subtitle> newSubtitle) {
     subtitle = Subtitles(newSubtitle);
+  }
+
+  /// Replaces the selectable [audioTracks] and rebuilds the controls.
+  ///
+  /// Use when tracks become known only after the media loads (e.g. once an
+  /// HLS manifest is parsed).
+  void setAudioTracks(List<AudioTrack> tracks) {
+    audioTracks = tracks;
+    notifyListeners();
+  }
+
+  /// Selects [track] as the active audio rendition, updating
+  /// [activeAudioTrackId] and notifying [onAudioTrackChanged].
+  void selectAudioTrack(AudioTrack track) {
+    activeAudioTrackId = track.id;
+    onAudioTrackChanged?.call(track);
+    notifyListeners();
   }
 }
 

--- a/lib/src/material/material_controls.dart
+++ b/lib/src/material/material_controls.dart
@@ -6,8 +6,10 @@ import 'package:chewie/src/chewie_player.dart';
 import 'package:chewie/src/chewie_progress_colors.dart';
 import 'package:chewie/src/helpers/utils.dart';
 import 'package:chewie/src/material/material_progress_bar.dart';
+import 'package:chewie/src/material/widgets/audio_track_dialog.dart';
 import 'package:chewie/src/material/widgets/options_dialog.dart';
 import 'package:chewie/src/material/widgets/playback_speed_dialog.dart';
+import 'package:chewie/src/models/audio_track.dart';
 import 'package:chewie/src/models/option_item.dart';
 import 'package:chewie/src/models/subtitle_model.dart';
 import 'package:chewie/src/notifiers/index.dart';
@@ -165,6 +167,15 @@ class _MaterialControlsState extends State<MaterialControls>
             chewieController.optionsTranslation?.playbackSpeedButtonText ??
             'Playback speed',
       ),
+      if (chewieController.hasAudioTracks)
+        OptionItem(
+          onTap: (context) async {
+            Navigator.pop(context);
+            await _onAudioTrackButtonTap();
+          },
+          iconData: Icons.audiotrack_outlined,
+          title: 'Audio',
+        ),
     ];
 
     if (chewieController.additionalOptions != null &&
@@ -484,6 +495,28 @@ class _MaterialControlsState extends State<MaterialControls>
     setState(() {
       _subtitleOn = !_subtitleOn;
     });
+  }
+
+  Future<void> _onAudioTrackButtonTap() async {
+    _hideTimer?.cancel();
+
+    final track = await showModalBottomSheet<AudioTrack>(
+      context: context,
+      isScrollControlled: true,
+      useRootNavigator: chewieController.useRootNavigator,
+      builder: (context) => AudioTrackDialog(
+        tracks: chewieController.audioTracks,
+        selectedId: chewieController.activeAudioTrackId,
+      ),
+    );
+
+    if (track != null) {
+      chewieController.selectAudioTrack(track);
+    }
+
+    if (_latestValue.isPlaying) {
+      _startHideTimer();
+    }
   }
 
   void _cancelAndRestartTimer() {

--- a/lib/src/material/material_desktop_controls.dart
+++ b/lib/src/material/material_desktop_controls.dart
@@ -6,8 +6,10 @@ import 'package:chewie/src/chewie_player.dart';
 import 'package:chewie/src/chewie_progress_colors.dart';
 import 'package:chewie/src/helpers/utils.dart';
 import 'package:chewie/src/material/material_progress_bar.dart';
+import 'package:chewie/src/material/widgets/audio_track_dialog.dart';
 import 'package:chewie/src/material/widgets/options_dialog.dart';
 import 'package:chewie/src/material/widgets/playback_speed_dialog.dart';
+import 'package:chewie/src/models/audio_track.dart';
 import 'package:chewie/src/models/option_item.dart';
 import 'package:chewie/src/models/subtitle_model.dart';
 import 'package:chewie/src/notifiers/index.dart';
@@ -183,6 +185,15 @@ class _MaterialDesktopControlsState extends State<MaterialDesktopControls>
             chewieController.optionsTranslation?.playbackSpeedButtonText ??
             'Playback speed',
       ),
+      if (chewieController.hasAudioTracks)
+        OptionItem(
+          onTap: (context) async {
+            Navigator.pop(context);
+            await _onAudioTrackButtonTap();
+          },
+          iconData: Icons.audiotrack_outlined,
+          title: 'Audio',
+        ),
     ];
 
     if (chewieController.additionalOptions != null &&
@@ -449,6 +460,28 @@ class _MaterialDesktopControlsState extends State<MaterialDesktopControls>
     setState(() {
       _subtitleOn = !_subtitleOn;
     });
+  }
+
+  Future<void> _onAudioTrackButtonTap() async {
+    _hideTimer?.cancel();
+
+    final track = await showModalBottomSheet<AudioTrack>(
+      context: context,
+      isScrollControlled: true,
+      useRootNavigator: chewieController.useRootNavigator,
+      builder: (context) => AudioTrackDialog(
+        tracks: chewieController.audioTracks,
+        selectedId: chewieController.activeAudioTrackId,
+      ),
+    );
+
+    if (track != null) {
+      chewieController.selectAudioTrack(track);
+    }
+
+    if (_latestValue.isPlaying) {
+      _startHideTimer();
+    }
   }
 
   void _cancelAndRestartTimer() {

--- a/lib/src/material/widgets/audio_track_dialog.dart
+++ b/lib/src/material/widgets/audio_track_dialog.dart
@@ -1,0 +1,50 @@
+import 'package:chewie/src/models/audio_track.dart';
+import 'package:flutter/material.dart';
+
+/// Lets the user pick one of the available [AudioTrack]s. Pops with the chosen
+/// [AudioTrack], or `null` when dismissed. Unlike subtitles there is no "off"
+/// option — one audio track is always active.
+class AudioTrackDialog extends StatelessWidget {
+  const AudioTrackDialog({
+    super.key,
+    required List<AudioTrack> tracks,
+    required Object? selectedId,
+  })  : _tracks = tracks,
+        _selectedId = selectedId;
+
+  final List<AudioTrack> _tracks;
+  final Object? _selectedId;
+
+  @override
+  Widget build(BuildContext context) {
+    final Color selectedColor = Theme.of(context).primaryColor;
+
+    return ListView(
+      shrinkWrap: true,
+      physics: const ScrollPhysics(),
+      children: [
+        for (final track in _tracks)
+          ListTile(
+            dense: true,
+            selected: track.id == _selectedId,
+            onTap: () => Navigator.of(context).pop(track),
+            title: Row(
+              children: [
+                if (track.id == _selectedId)
+                  Icon(Icons.check, size: 20.0, color: selectedColor)
+                else
+                  const SizedBox(width: 20.0),
+                const SizedBox(width: 16.0),
+                Expanded(child: Text(track.label)),
+                if (track.language != null)
+                  Text(
+                    track.language!,
+                    style: Theme.of(context).textTheme.bodySmall,
+                  ),
+              ],
+            ),
+          ),
+      ],
+    );
+  }
+}

--- a/lib/src/material/widgets/audio_track_dialog.dart
+++ b/lib/src/material/widgets/audio_track_dialog.dart
@@ -9,8 +9,8 @@ class AudioTrackDialog extends StatelessWidget {
     super.key,
     required List<AudioTrack> tracks,
     required Object? selectedId,
-  })  : _tracks = tracks,
-        _selectedId = selectedId;
+  }) : _tracks = tracks,
+       _selectedId = selectedId;
 
   final List<AudioTrack> _tracks;
   final Object? _selectedId;

--- a/lib/src/models/audio_track.dart
+++ b/lib/src/models/audio_track.dart
@@ -6,11 +6,7 @@
 /// playing rendition is left to the host. Unlike subtitles, audio is never
 /// "off": one track is always active.
 class AudioTrack {
-  const AudioTrack({
-    required this.id,
-    required this.label,
-    this.language,
-  });
+  const AudioTrack({required this.id, required this.label, this.language});
 
   /// Opaque identifier the host uses to recognise the track on selection.
   final Object id;
@@ -32,5 +28,6 @@ class AudioTrack {
   int get hashCode => Object.hash(id, label, language);
 
   @override
-  String toString() => 'AudioTrack(id: $id, label: $label, language: $language)';
+  String toString() =>
+      'AudioTrack(id: $id, label: $label, language: $language)';
 }

--- a/lib/src/models/audio_track.dart
+++ b/lib/src/models/audio_track.dart
@@ -1,0 +1,36 @@
+/// A selectable audio track surfaced in the player's options menu.
+///
+/// This is intentionally decoupled from any particular source (HLS, embedded
+/// renditions...). The host supplies the tracks and reacts to the user's
+/// selection through [ChewieController.onAudioTrackChanged]; switching the
+/// playing rendition is left to the host. Unlike subtitles, audio is never
+/// "off": one track is always active.
+class AudioTrack {
+  const AudioTrack({
+    required this.id,
+    required this.label,
+    this.language,
+  });
+
+  /// Opaque identifier the host uses to recognise the track on selection.
+  final Object id;
+
+  /// Human-readable name shown in the menu.
+  final String label;
+
+  /// Optional BCP-47 language tag, shown as a hint next to [label].
+  final String? language;
+
+  @override
+  bool operator ==(Object other) =>
+      other is AudioTrack &&
+      other.id == id &&
+      other.label == label &&
+      other.language == language;
+
+  @override
+  int get hashCode => Object.hash(id, label, language);
+
+  @override
+  String toString() => 'AudioTrack(id: $id, label: $label, language: $language)';
+}

--- a/lib/src/models/index.dart
+++ b/lib/src/models/index.dart
@@ -1,3 +1,4 @@
+export 'audio_track.dart';
 export 'option_item.dart';
 export 'options_translation.dart';
 export 'subtitle_model.dart';

--- a/test/audio_track_controller_test.dart
+++ b/test/audio_track_controller_test.dart
@@ -1,0 +1,108 @@
+import 'package:chewie/chewie.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:video_player/video_player.dart';
+
+const _tracks = <AudioTrack>[
+  AudioTrack(id: '0', label: 'English', language: 'en'),
+  AudioTrack(id: '1', label: 'French', language: 'fr'),
+];
+
+ChewieController _controllerWith({
+  List<AudioTrack> audioTracks = const <AudioTrack>[],
+  Object? activeAudioTrackId,
+  void Function(AudioTrack track)? onAudioTrackChanged,
+}) {
+  // autoInitialize/autoPlay stay false, so no platform plugin call is made.
+  return ChewieController(
+    videoPlayerController: VideoPlayerController.networkUrl(
+      Uri.parse('https://example.com/v.mp4'),
+    ),
+    audioTracks: audioTracks,
+    activeAudioTrackId: activeAudioTrackId,
+    onAudioTrackChanged: onAudioTrackChanged,
+  );
+}
+
+void main() {
+  // Needed so VideoPlayerController construction and setLooping (a no-op while
+  // uninitialized) don't trip over the missing test binding.
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('ChewieController.hasAudioTracks', () {
+    test('is false with no tracks', () {
+      expect(_controllerWith().hasAudioTracks, isFalse);
+    });
+
+    test('is false with a single track (nothing to choose)', () {
+      expect(
+        _controllerWith(
+          audioTracks: const [AudioTrack(id: '0', label: 'A')],
+        ).hasAudioTracks,
+        isFalse,
+      );
+    });
+
+    test('is true with two or more tracks', () {
+      expect(_controllerWith(audioTracks: _tracks).hasAudioTracks, isTrue);
+    });
+  });
+
+  test('setAudioTracks replaces the tracks and notifies listeners', () {
+    final controller = _controllerWith();
+    var notified = 0;
+    controller.addListener(() => notified++);
+
+    controller.setAudioTracks(_tracks);
+
+    expect(controller.audioTracks, _tracks);
+    expect(controller.hasAudioTracks, isTrue);
+    expect(notified, 1);
+  });
+
+  test(
+    'selectAudioTrack updates the active id, fires the callback and notifies',
+    () {
+      AudioTrack? selected;
+      final controller = _controllerWith(
+        audioTracks: _tracks,
+        onAudioTrackChanged: (track) => selected = track,
+      );
+      var notified = 0;
+      controller.addListener(() => notified++);
+
+      controller.selectAudioTrack(_tracks[1]);
+
+      expect(controller.activeAudioTrackId, '1');
+      expect(selected, _tracks[1]);
+      expect(notified, 1);
+    },
+  );
+
+  test('selectAudioTrack works without an onAudioTrackChanged callback', () {
+    final controller = _controllerWith(audioTracks: _tracks);
+    expect(() => controller.selectAudioTrack(_tracks[0]), returnsNormally);
+    expect(controller.activeAudioTrackId, '0');
+  });
+
+  test('copyWith carries the audio-track fields over', () {
+    final controller = _controllerWith();
+    final copy = controller.copyWith(
+      audioTracks: _tracks,
+      activeAudioTrackId: '1',
+    );
+
+    expect(copy.audioTracks, _tracks);
+    expect(copy.activeAudioTrackId, '1');
+  });
+
+  test('copyWith keeps the original audio-track fields when omitted', () {
+    final controller = _controllerWith(
+      audioTracks: _tracks,
+      activeAudioTrackId: '0',
+    );
+    final copy = controller.copyWith(autoPlay: false);
+
+    expect(copy.audioTracks, _tracks);
+    expect(copy.activeAudioTrackId, '0');
+  });
+}

--- a/test/material/audio_track_controls_test.dart
+++ b/test/material/audio_track_controls_test.dart
@@ -1,0 +1,115 @@
+import 'package:chewie/chewie.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:video_player/video_player.dart';
+
+const _tracks = <AudioTrack>[
+  AudioTrack(id: '0', label: 'English', language: 'en'),
+  AudioTrack(id: '1', label: 'French', language: 'fr'),
+];
+
+/// Builds a [ChewieController] that never touches the video_player platform
+/// (autoInitialize/autoPlay stay false) but exposes the two audio tracks.
+ChewieController _controller(
+  Widget controls, {
+  void Function(AudioTrack)? onChanged,
+}) {
+  return ChewieController(
+    videoPlayerController: VideoPlayerController.networkUrl(
+      Uri.parse('https://example.com/v.mp4'),
+    ),
+    autoPlay: false,
+    autoInitialize: false,
+    audioTracks: _tracks,
+    activeAudioTrackId: '0',
+    onAudioTrackChanged: onChanged,
+    customControls: controls,
+  );
+}
+
+/// Opens the options menu via [optionsIcon], taps the "Audio" entry, then picks
+/// "French" — exercising the controls' audio-track code path end to end.
+Future<void> _runFlow(
+  WidgetTester tester, {
+  required Widget controls,
+  required IconData optionsIcon,
+}) async {
+  AudioTrack? chosen;
+  final controller = _controller(controls, onChanged: (t) => chosen = t);
+
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(body: Chewie(controller: controller)),
+    ),
+  );
+  // Let the show-controls-on-initialize timer fire so the controls become
+  // interactive (otherwise AbsorbPointer swallows the tap).
+  await tester.pump(const Duration(milliseconds: 300));
+
+  // Open the options bottom sheet.
+  await tester.tap(find.byIcon(optionsIcon));
+  await tester.pumpAndSettle();
+  expect(find.text('Audio'), findsOneWidget);
+
+  // Open the audio-track dialog.
+  await tester.tap(find.text('Audio'));
+  await tester.pumpAndSettle();
+  expect(find.text('English'), findsOneWidget);
+  expect(find.text('French'), findsOneWidget);
+
+  // Pick a track.
+  await tester.tap(find.text('French'));
+  await tester.pumpAndSettle();
+
+  expect(chosen, _tracks[1]);
+  expect(controller.activeAudioTrackId, '1');
+}
+
+void main() {
+  testWidgets('MaterialControls: options menu exposes audio-track selection', (
+    tester,
+  ) async {
+    await _runFlow(
+      tester,
+      controls: const MaterialControls(),
+      optionsIcon: Icons.more_vert,
+    );
+  });
+
+  testWidgets(
+    'MaterialDesktopControls: options menu exposes audio-track selection',
+    (tester) async {
+      await _runFlow(
+        tester,
+        controls: const MaterialDesktopControls(),
+        optionsIcon: Icons.settings,
+      );
+    },
+  );
+
+  testWidgets('the Audio entry is hidden when there is only one track', (
+    tester,
+  ) async {
+    final controller = ChewieController(
+      videoPlayerController: VideoPlayerController.networkUrl(
+        Uri.parse('https://example.com/v.mp4'),
+      ),
+      autoPlay: false,
+      autoInitialize: false,
+      audioTracks: const [AudioTrack(id: '0', label: 'English')],
+      customControls: const MaterialControls(),
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(body: Chewie(controller: controller)),
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 300));
+
+    await tester.tap(find.byIcon(Icons.more_vert));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Audio'), findsNothing);
+  });
+}

--- a/test/material/audio_track_dialog_test.dart
+++ b/test/material/audio_track_dialog_test.dart
@@ -1,0 +1,93 @@
+import 'package:chewie/chewie.dart';
+import 'package:chewie/src/material/widgets/audio_track_dialog.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const _tracks = <AudioTrack>[
+  AudioTrack(id: '0', label: 'English', language: 'en'),
+  AudioTrack(id: '1', label: 'French', language: 'fr'),
+  AudioTrack(id: '2', label: 'No language'),
+];
+
+/// Pumps a screen with a button that opens the [AudioTrackDialog] in a modal
+/// bottom sheet, taps it, and lets the caller inspect/interact with the sheet.
+/// The chosen track (or null) lands in [resultHolder] once the sheet closes.
+Future<void> _openDialog(
+  WidgetTester tester, {
+  required Object? selectedId,
+  required List<AudioTrack?> resultHolder,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: Builder(
+          builder: (context) => Center(
+            child: ElevatedButton(
+              onPressed: () async {
+                final track = await showModalBottomSheet<AudioTrack>(
+                  context: context,
+                  builder: (_) =>
+                      AudioTrackDialog(tracks: _tracks, selectedId: selectedId),
+                );
+                resultHolder.add(track);
+              },
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+
+  await tester.tap(find.text('open'));
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  testWidgets('renders one tile per track with its label', (tester) async {
+    await _openDialog(tester, selectedId: '0', resultHolder: []);
+
+    expect(find.byType(ListTile), findsNWidgets(_tracks.length));
+    expect(find.text('English'), findsOneWidget);
+    expect(find.text('French'), findsOneWidget);
+    expect(find.text('No language'), findsOneWidget);
+  });
+
+  testWidgets('shows a check icon next to the selected track only', (
+    tester,
+  ) async {
+    await _openDialog(tester, selectedId: '1', resultHolder: []);
+
+    expect(find.byIcon(Icons.check), findsOneWidget);
+  });
+
+  testWidgets('shows the language code only for tracks that have one', (
+    tester,
+  ) async {
+    await _openDialog(tester, selectedId: null, resultHolder: []);
+
+    expect(find.text('en'), findsOneWidget);
+    expect(find.text('fr'), findsOneWidget);
+  });
+
+  testWidgets('tapping a track pops the sheet with that track', (tester) async {
+    final result = <AudioTrack?>[];
+    await _openDialog(tester, selectedId: '0', resultHolder: result);
+
+    await tester.tap(find.text('French'));
+    await tester.pumpAndSettle();
+
+    expect(result, [_tracks[1]]);
+  });
+
+  testWidgets('dismissing the sheet pops with null', (tester) async {
+    final result = <AudioTrack?>[];
+    await _openDialog(tester, selectedId: '0', resultHolder: result);
+
+    // Tap the scrim above the sheet to dismiss it.
+    await tester.tapAt(const Offset(10, 10));
+    await tester.pumpAndSettle();
+
+    expect(result, [null]);
+  });
+}

--- a/test/models/audio_track_test.dart
+++ b/test/models/audio_track_test.dart
@@ -1,0 +1,53 @@
+import 'package:chewie/chewie.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('AudioTrack equality', () {
+    test('two tracks with the same id, label and language are equal', () {
+      const a = AudioTrack(id: '0', label: 'English', language: 'en');
+      const b = AudioTrack(id: '0', label: 'English', language: 'en');
+      expect(a, equals(b));
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('tracks differing in id are not equal', () {
+      const a = AudioTrack(id: '0', label: 'English', language: 'en');
+      const b = AudioTrack(id: '1', label: 'English', language: 'en');
+      expect(a, isNot(equals(b)));
+    });
+
+    test('tracks differing in label are not equal', () {
+      const a = AudioTrack(id: '0', label: 'English', language: 'en');
+      const b = AudioTrack(id: '0', label: 'Anglais', language: 'en');
+      expect(a, isNot(equals(b)));
+    });
+
+    test('tracks differing in language are not equal', () {
+      const a = AudioTrack(id: '0', label: 'English', language: 'en');
+      const b = AudioTrack(id: '0', label: 'English', language: 'fr');
+      expect(a, isNot(equals(b)));
+    });
+
+    test('an AudioTrack is not equal to another type', () {
+      const a = AudioTrack(id: '0', label: 'English');
+      expect(a == Object(), isFalse);
+    });
+
+    test('the id may be any Object, not just a String', () {
+      const a = AudioTrack(id: 0, label: 'English');
+      const b = AudioTrack(id: 0, label: 'English');
+      expect(a, equals(b));
+      expect(a.hashCode, b.hashCode);
+    });
+  });
+
+  test('language is optional and defaults to null', () {
+    const track = AudioTrack(id: '0', label: 'English');
+    expect(track.language, isNull);
+  });
+
+  test('toString lists the fields', () {
+    const track = AudioTrack(id: '0', label: 'English', language: 'en');
+    expect(track.toString(), 'AudioTrack(id: 0, label: English, language: en)');
+  });
+}


### PR DESCRIPTION
## Motivation

Streaming sources (notably HLS) expose multiple **audio renditions** (languages, commentary, codecs) in their manifest, but Chewie has no UI to switch between them. This adds a source-agnostic audio-track picker to the Material controls.

## What this adds

- An audio-track picker in the options menu, shown only when **more than one** track is available (a single track offers nothing to choose).
- Unlike subtitles, audio is never "off": one track is always active.

The widget is **source-agnostic**: the host populates the track list and performs the actual rendition switch; Chewie never assumes HLS or any particular backend.

## API (all opt-in — defaults preserve current behavior)

`ChewieController`:
- `List<AudioTrack> audioTracks` — selectable tracks (default empty).
- `Object? activeAudioTrackId` — currently selected id.
- `void Function(AudioTrack)? onAudioTrackChanged` — selection callback.
- `setAudioTracks()` / `selectAudioTrack()` — for tracks known only after load.
- `bool get hasAudioTracks` — true only when `length > 1`; gates the menu entry.

New: `AudioTrack` model and `AudioTrackDialog` bottom sheet.

## Backwards compatibility

Fully backwards compatible — every field is optional and defaults to the current behavior. No menu entry appears unless the host provides more than one track.

## Testing

- `dart analyze` — no issues.
- In production use in an HLS web player (audio renditions parsed from the manifest, switched on selection).

Independent of the subtitle-track PR (#948) — single commit, based on `master`.