### PR TITLE
feat: show click (pointer) cursor on hover over Material controls and progress bar

### DIFF
--- a/lib/src/material/material_controls.dart
+++ b/lib/src/material/material_controls.dart
@@ -304,16 +304,19 @@ class _MaterialControlsState extends State<MaterialControls>
           controller.setVolume(0.0);
         }
       },
-      child: AnimatedOpacity(
-        opacity: notifier.hideStuff ? 0.0 : 1.0,
-        duration: const Duration(milliseconds: 300),
-        child: ClipRect(
-          child: Container(
-            height: barHeight,
-            padding: const EdgeInsets.only(left: 6.0),
-            child: Icon(
-              _latestValue.volume > 0 ? Icons.volume_up : Icons.volume_off,
-              color: Colors.white,
+      child: MouseRegion(
+        cursor: SystemMouseCursors.click,
+        child: AnimatedOpacity(
+          opacity: notifier.hideStuff ? 0.0 : 1.0,
+          duration: const Duration(milliseconds: 300),
+          child: ClipRect(
+            child: Container(
+              height: barHeight,
+              padding: const EdgeInsets.only(left: 6.0),
+              child: Icon(
+                _latestValue.volume > 0 ? Icons.volume_up : Icons.volume_off,
+                color: Colors.white,
+              ),
             ),
           ),
         ),
@@ -324,19 +327,22 @@ class _MaterialControlsState extends State<MaterialControls>
   GestureDetector _buildExpandButton() {
     return GestureDetector(
       onTap: _onExpandCollapse,
-      child: AnimatedOpacity(
-        opacity: notifier.hideStuff ? 0.0 : 1.0,
-        duration: const Duration(milliseconds: 300),
-        child: Container(
-          height: barHeight + (chewieController.isFullScreen ? 15.0 : 0),
-          margin: const EdgeInsets.only(right: 12.0),
-          padding: const EdgeInsets.only(left: 8.0, right: 8.0),
-          child: Center(
-            child: Icon(
-              chewieController.isFullScreen
-                  ? Icons.fullscreen_exit
-                  : Icons.fullscreen,
-              color: Colors.white,
+      child: MouseRegion(
+        cursor: SystemMouseCursors.click,
+        child: AnimatedOpacity(
+          opacity: notifier.hideStuff ? 0.0 : 1.0,
+          duration: const Duration(milliseconds: 300),
+          child: Container(
+            height: barHeight + (chewieController.isFullScreen ? 15.0 : 0),
+            margin: const EdgeInsets.only(right: 12.0),
+            padding: const EdgeInsets.only(left: 8.0, right: 8.0),
+            child: Center(
+              child: Icon(
+                chewieController.isFullScreen
+                    ? Icons.fullscreen_exit
+                    : Icons.fullscreen,
+                color: Colors.white,
+              ),
             ),
           ),
         ),
@@ -473,15 +479,18 @@ class _MaterialControlsState extends State<MaterialControls>
     }
     return GestureDetector(
       onTap: _onSubtitleTap,
-      child: Container(
-        height: barHeight,
-        color: Colors.transparent,
-        padding: const EdgeInsets.only(left: 12.0, right: 12.0),
-        child: Icon(
-          _subtitleOn
-              ? Icons.closed_caption
-              : Icons.closed_caption_off_outlined,
-          color: _subtitleOn ? Colors.white : Colors.grey[700],
+      child: MouseRegion(
+        cursor: SystemMouseCursors.click,
+        child: Container(
+          height: barHeight,
+          color: Colors.transparent,
+          padding: const EdgeInsets.only(left: 12.0, right: 12.0),
+          child: Icon(
+            _subtitleOn
+                ? Icons.closed_caption
+                : Icons.closed_caption_off_outlined,
+            color: _subtitleOn ? Colors.white : Colors.grey[700],
+          ),
         ),
       ),
     );

--- a/lib/src/material/material_desktop_controls.dart
+++ b/lib/src/material/material_desktop_controls.dart
@@ -314,19 +314,22 @@ class _MaterialDesktopControlsState extends State<MaterialDesktopControls>
   GestureDetector _buildExpandButton() {
     return GestureDetector(
       onTap: _onExpandCollapse,
-      child: AnimatedOpacity(
-        opacity: notifier.hideStuff ? 0.0 : 1.0,
-        duration: const Duration(milliseconds: 300),
-        child: Container(
-          height: barHeight + (chewieController.isFullScreen ? 15.0 : 0),
-          margin: const EdgeInsets.only(right: 12.0),
-          padding: const EdgeInsets.only(left: 8.0, right: 8.0),
-          child: Center(
-            child: Icon(
-              chewieController.isFullScreen
-                  ? Icons.fullscreen_exit
-                  : Icons.fullscreen,
-              color: Colors.white,
+      child: MouseRegion(
+        cursor: SystemMouseCursors.click,
+        child: AnimatedOpacity(
+          opacity: notifier.hideStuff ? 0.0 : 1.0,
+          duration: const Duration(milliseconds: 300),
+          child: Container(
+            height: barHeight + (chewieController.isFullScreen ? 15.0 : 0),
+            margin: const EdgeInsets.only(right: 12.0),
+            padding: const EdgeInsets.only(left: 8.0, right: 8.0),
+            child: Center(
+              child: Icon(
+                chewieController.isFullScreen
+                    ? Icons.fullscreen_exit
+                    : Icons.fullscreen,
+                color: Colors.white,
+              ),
             ),
           ),
         ),
@@ -409,16 +412,19 @@ class _MaterialDesktopControlsState extends State<MaterialDesktopControls>
           controller.setVolume(0.0);
         }
       },
-      child: AnimatedOpacity(
-        opacity: notifier.hideStuff ? 0.0 : 1.0,
-        duration: const Duration(milliseconds: 300),
-        child: ClipRect(
-          child: Container(
-            height: barHeight,
-            padding: const EdgeInsets.only(right: 15.0),
-            child: Icon(
-              _latestValue.volume > 0 ? Icons.volume_up : Icons.volume_off,
-              color: Colors.white,
+      child: MouseRegion(
+        cursor: SystemMouseCursors.click,
+        child: AnimatedOpacity(
+          opacity: notifier.hideStuff ? 0.0 : 1.0,
+          duration: const Duration(milliseconds: 300),
+          child: ClipRect(
+            child: Container(
+              height: barHeight,
+              padding: const EdgeInsets.only(right: 15.0),
+              child: Icon(
+                _latestValue.volume > 0 ? Icons.volume_up : Icons.volume_off,
+                color: Colors.white,
+              ),
             ),
           ),
         ),
@@ -429,14 +435,17 @@ class _MaterialDesktopControlsState extends State<MaterialDesktopControls>
   GestureDetector _buildPlayPause(VideoPlayerController controller) {
     return GestureDetector(
       onTap: _playPause,
-      child: Container(
-        height: barHeight,
-        color: Colors.transparent,
-        margin: const EdgeInsets.only(left: 8.0, right: 4.0),
-        padding: const EdgeInsets.only(left: 12.0, right: 12.0),
-        child: AnimatedPlayPause(
-          playing: controller.value.isPlaying,
-          color: Colors.white,
+      child: MouseRegion(
+        cursor: SystemMouseCursors.click,
+        child: Container(
+          height: barHeight,
+          color: Colors.transparent,
+          margin: const EdgeInsets.only(left: 8.0, right: 4.0),
+          padding: const EdgeInsets.only(left: 12.0, right: 12.0),
+          child: AnimatedPlayPause(
+            playing: controller.value.isPlaying,
+            color: Colors.white,
+          ),
         ),
       ),
     );

--- a/lib/src/progress_bar.dart
+++ b/lib/src/progress_bar.dart
@@ -117,7 +117,7 @@ class _VideoProgressBarState extends State<VideoProgressBar> {
               }
               _seekToRelativePosition(details.globalPosition);
             },
-            child: child,
+            child: MouseRegion(cursor: SystemMouseCursors.click, child: child),
           )
         : child;
   }


### PR DESCRIPTION
## Description

On web and desktop, hovering the mouse over the player controls keeps the default arrow cursor — there's no affordance that the buttons and the seek bar are clickable.

The affected controls (play/pause, mute, subtitle toggle, fullscreen, and the draggable progress bar) are built with `GestureDetector`, which — unlike `IconButton` — does not set a hover cursor. The options/subtitles `IconButton`s already show a pointer, so the bar is inconsistent.

This PR wraps the clickable child of each of those `GestureDetector`s in a `MouseRegion(cursor: SystemMouseCursors.click)` so the cursor turns into a pointer on hover, matching the `IconButton`-based controls.

## What changed

- `MaterialControls` — mute, fullscreen, subtitle toggle
- `MaterialDesktopControls` — play/pause, mute, fullscreen
- `VideoProgressBar` (shared) — the draggable progress/seek bar only; the non-draggable variant is left untouched

`CupertinoControls` is intentionally left out: it is touch-first (iOS) and its root already wraps everything in a `MouseRegion`. Happy to extend it in a follow-up if maintainers prefer full coverage.

## Behavior

- No functional or layout change — `MouseRegion` only affects the hover cursor.
- The pointer region matches the existing tap region exactly (the `MouseRegion` wraps the same child the `GestureDetector` already used).

## Testing

- `flutter analyze` — no issues.
- Built and ran the `example/` app on web; controls behave identically, with the pointer cursor now appearing on hover over the buttons and the seek bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)