### PR TITLE
1.14.1 fullscreen fix

### DIFF
--- a/lib/src/chewie_player.dart
+++ b/lib/src/chewie_player.dart
@@ -652,10 +652,6 @@ class ChewieController extends ChangeNotifier {
     }
 
     if (autoPlay) {
-      if (fullScreenByDefault) {
-        enterFullScreen();
-      }
-
       await videoPlayerController.play();
     }
 
@@ -664,14 +660,16 @@ class ChewieController extends ChangeNotifier {
     }
 
     if (fullScreenByDefault) {
-      videoPlayerController.addListener(_fullScreenListener);
+      videoPlayerController.addListener(_fullScreenByDefaultListener);
     }
   }
 
-  Future<void> _fullScreenListener() async {
-    if (videoPlayerController.value.isPlaying && !_isFullScreen) {
+  Future<void> _fullScreenByDefaultListener() async {
+    if (videoPlayerController.value.isPlaying &&
+        fullScreenByDefault &&
+        !_isFullScreen) {
       enterFullScreen();
-      videoPlayerController.removeListener(_fullScreenListener);
+      videoPlayerController.removeListener(_fullScreenByDefaultListener);
     }
   }
 

--- a/lib/src/chewie_player.dart
+++ b/lib/src/chewie_player.dart
@@ -660,16 +660,17 @@ class ChewieController extends ChangeNotifier {
     }
 
     if (fullScreenByDefault) {
-      videoPlayerController.addListener(_fullScreenByDefaultListener);
+      videoPlayerController.addListener(_tryToEnableFullScreen);
     }
   }
 
-  Future<void> _fullScreenByDefaultListener() async {
-    if (videoPlayerController.value.isPlaying &&
-        fullScreenByDefault &&
-        !_isFullScreen) {
+  Future<void> _tryToEnableFullScreen() async {
+    if (fullScreenByDefault &&
+        _isFullScreen == false &&
+        videoPlayerController.value.isPlaying &&
+        hasListeners) {
       enterFullScreen();
-      videoPlayerController.removeListener(_fullScreenByDefaultListener);
+      videoPlayerController.removeListener(_tryToEnableFullScreen);
     }
   }
 


### PR DESCRIPTION
The first attempt to go full screen just after checking if autoPlay is on fails and prevents the second want to be done.

See bug reported here for more information https://github.com/fluttercommunity/chewie/issues/710

previous PR was no longer compatible with the latest codebase but the bug is still there : https://github.com/fluttercommunity/chewie/pull/711