### PR TITLE
feat: auto-hide the mouse cursor while idle in fullscreen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [Unreleased]
+* 🖱️ [#954](https://github.com/fluttercommunity/chewie/pull/954): Auto-hide the mouse cursor along with the controls while idle in fullscreen, and show it again on mouse movement (web and desktop). Configurable via `ChewieController.hideCursorInFullScreen` (default `true`). Thanks [Ortes](https://github.com/Ortes).
+
 ## [1.15.0]
 * 🌐 [#946](https://github.com/fluttercommunity/chewie/pull/946): Web: enter the browser's native (OS-level) fullscreen via the Fullscreen API instead of only expanding the Flutter view inside the browser window. Pressing Escape to leave browser fullscreen also exits Chewie's fullscreen. Controlled by the new `ChewieController.useNativeFullScreenOnWeb` flag (defaults to `true`; no effect on non-web platforms). Thanks [Ortes](https://github.com/Ortes).
 * 🖱️ [#950](https://github.com/fluttercommunity/chewie/pull/950): Show click cursor on hover over Material controls and progress bar. Thanks [Ortes](https://github.com/Ortes).

--- a/lib/src/chewie_player.dart
+++ b/lib/src/chewie_player.dart
@@ -364,6 +364,7 @@ class ChewieController extends ChangeNotifier {
     this.hideControlsTimer = defaultHideControlsTimer,
     this.controlsSafeAreaMinimum = EdgeInsets.zero,
     this.pauseOnBackgroundTap = false,
+    this.hideCursorInFullScreen = true,
   }) : assert(
          playbackSpeeds.every((speed) => speed > 0),
          'The playbackSpeeds values must all be greater than 0',
@@ -425,6 +426,7 @@ class ChewieController extends ChangeNotifier {
     )?
     routePageBuilder,
     bool? pauseOnBackgroundTap,
+    bool? hideCursorInFullScreen,
   }) {
     return ChewieController(
       draggableProgressBar: draggableProgressBar ?? this.draggableProgressBar,
@@ -492,6 +494,8 @@ class ChewieController extends ChangeNotifier {
       progressIndicatorDelay:
           progressIndicatorDelay ?? this.progressIndicatorDelay,
       pauseOnBackgroundTap: pauseOnBackgroundTap ?? this.pauseOnBackgroundTap,
+      hideCursorInFullScreen:
+          hideCursorInFullScreen ?? this.hideCursorInFullScreen,
     );
   }
 
@@ -684,6 +688,12 @@ class ChewieController extends ChangeNotifier {
 
   /// Defines if the player should pause when the background is tapped
   final bool pauseOnBackgroundTap;
+
+  /// Whether the mouse cursor auto-hides together with the controls while in
+  /// fullscreen (and reappears on mouse movement), like most video players.
+  /// Has no effect outside fullscreen or on devices without a pointer.
+  /// Defaults to `true`.
+  final bool hideCursorInFullScreen;
 
   static ChewieController of(BuildContext context) {
     final chewieControllerProvider = context

--- a/lib/src/cupertino/cupertino_controls.dart
+++ b/lib/src/cupertino/cupertino_controls.dart
@@ -57,6 +57,14 @@ class _CupertinoControlsState extends State<CupertinoControls>
   ChewieController get chewieController => _chewieController!;
   ChewieController? _chewieController;
 
+  // Hides the mouse cursor along with the controls while idle in fullscreen.
+  MouseCursor get _idleCursor =>
+      chewieController.hideCursorInFullScreen &&
+          chewieController.isFullScreen &&
+          notifier.hideStuff
+      ? SystemMouseCursors.none
+      : MouseCursor.defer;
+
   @override
   void initState() {
     super.initState();
@@ -87,6 +95,7 @@ class _CupertinoControlsState extends State<CupertinoControls>
     final buttonPadding = orientation == Orientation.portrait ? 16.0 : 24.0;
 
     return MouseRegion(
+      cursor: _idleCursor,
       onHover: (_) => _cancelAndRestartTimer(),
       child: GestureDetector(
         onTap: () => _cancelAndRestartTimer(),

--- a/lib/src/material/material_controls.dart
+++ b/lib/src/material/material_controls.dart
@@ -51,6 +51,14 @@ class _MaterialControlsState extends State<MaterialControls>
   // We know that _chewieController is set in didChangeDependencies
   ChewieController get chewieController => _chewieController!;
 
+  // Hides the mouse cursor along with the controls while idle in fullscreen.
+  MouseCursor get _idleCursor =>
+      chewieController.hideCursorInFullScreen &&
+          chewieController.isFullScreen &&
+          notifier.hideStuff
+      ? SystemMouseCursors.none
+      : MouseCursor.defer;
+
   @override
   void initState() {
     super.initState();
@@ -68,6 +76,7 @@ class _MaterialControlsState extends State<MaterialControls>
     }
 
     return MouseRegion(
+      cursor: _idleCursor,
       onHover: (_) {
         _cancelAndRestartTimer();
       },

--- a/lib/src/material/material_desktop_controls.dart
+++ b/lib/src/material/material_desktop_controls.dart
@@ -53,6 +53,14 @@ class _MaterialDesktopControlsState extends State<MaterialDesktopControls>
   // We know that _chewieController is set in didChangeDependencies
   ChewieController get chewieController => _chewieController!;
 
+  // Hides the mouse cursor along with the controls while idle in fullscreen.
+  MouseCursor get _idleCursor =>
+      chewieController.hideCursorInFullScreen &&
+          chewieController.isFullScreen &&
+          notifier.hideStuff
+      ? SystemMouseCursors.none
+      : MouseCursor.defer;
+
   @override
   void initState() {
     super.initState();
@@ -92,6 +100,7 @@ class _MaterialDesktopControlsState extends State<MaterialDesktopControls>
       focusNode: _focusNode,
       onKeyEvent: _handleKeyPress,
       child: MouseRegion(
+        cursor: _idleCursor,
         onHover: (_) {
           _focusNode.requestFocus();
           _cancelAndRestartTimer();

--- a/test/hide_cursor_test.dart
+++ b/test/hide_cursor_test.dart
@@ -1,0 +1,57 @@
+import 'package:chewie/chewie.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:video_player/video_player.dart';
+
+const _src =
+    'https://assets.mixkit.co/videos/preview/mixkit-spinning-around-the-earth-29351-large.mp4';
+
+ChewieController _controller() {
+  return ChewieController(
+    videoPlayerController: VideoPlayerController.networkUrl(Uri.parse(_src)),
+    autoPlay: false,
+    looping: false,
+    customControls: const MaterialDesktopControls(),
+  );
+}
+
+Finder _hiddenCursor() => find.byWidgetPredicate(
+  (w) => w is MouseRegion && w.cursor == SystemMouseCursors.none,
+);
+
+void main() {
+  testWidgets(
+    'cursor is never hidden while not in fullscreen, even when idle',
+    (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: Chewie(controller: _controller())),
+        ),
+      );
+      await tester.pump();
+
+      // Drive a mouse hover so the controls arm their auto-hide timer, then let
+      // the player go idle (controls hidden).
+      final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+      await gesture.addPointer(location: tester.getCenter(find.byType(Chewie)));
+      addTearDown(gesture.removePointer);
+      await gesture.moveTo(tester.getCenter(find.byType(Chewie)));
+      await tester.pump(const Duration(seconds: 4));
+
+      // Idle outside fullscreen must not hide the cursor.
+      expect(_hiddenCursor(), findsNothing);
+    },
+  );
+
+  test('hideCursorInFullScreen defaults to true and survives copyWith', () {
+    final controller = ChewieController(
+      videoPlayerController: VideoPlayerController.networkUrl(Uri.parse(_src)),
+    );
+    expect(controller.hideCursorInFullScreen, isTrue);
+    expect(
+      controller.copyWith(hideCursorInFullScreen: false).hideCursorInFullScreen,
+      isFalse,
+    );
+  });
+}


### PR DESCRIPTION
## What

In fullscreen the mouse cursor currently stays visible forever. This makes it auto-hide together with the controls once the player goes idle, and reappear as soon as the mouse moves — the behaviour of most video players (YouTube, VLC, …).

## How

- Each controls widget already wraps the whole video surface in a root `MouseRegion` whose `onHover` reveals the controls. We simply set that region's `cursor` to `SystemMouseCursors.none` while `hideCursorInFullScreen && isFullScreen && hideStuff`, and `MouseCursor.defer` otherwise (so inner per-widget cursors still win when the controls are visible).
- Applied to all three control sets (`MaterialDesktopControls`, `MaterialControls`, `CupertinoControls`), matching the cross-file precedent of `pauseOnBackgroundTap`.
- No new timer or platform channel: `SystemMouseCursors.none` maps to CSS `cursor: none` on web and works on desktop too; it is a no-op on pointerless devices.
- Gated by a new `ChewieController.hideCursorInFullScreen` option (default `true`), wired through `copyWith`.

## Tests

`test/hide_cursor_test.dart` covers the option default/`copyWith` and that the cursor is never hidden while **not** in fullscreen even when the controls are idle (the gate).

`dart format`, `flutter analyze lib test`, and the full `flutter test` suite are clean.