### PR TITLE
feat: toggle fullscreen with the F key on desktop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [Unreleased]
+* ⬆️ [#955](https://github.com/fluttercommunity/chewie/pull/955): Add an `F` keyboard shortcut to toggle fullscreen on the desktop controls (respects `allowFullScreen`), complementing the existing `Esc`-to-exit shortcut. Thanks [Ortes](https://github.com/Ortes).
+
 ## [1.15.0]
 * 🌐 [#946](https://github.com/fluttercommunity/chewie/pull/946): Web: enter the browser's native (OS-level) fullscreen via the Fullscreen API instead of only expanding the Flutter view inside the browser window. Pressing Escape to leave browser fullscreen also exits Chewie's fullscreen. Controlled by the new `ChewieController.useNativeFullScreenOnWeb` flag (defaults to `true`; no effect on non-web platforms). Thanks [Ortes](https://github.com/Ortes).
 * 🖱️ [#950](https://github.com/fluttercommunity/chewie/pull/950): Show click cursor on hover over Material controls and progress bar. Thanks [Ortes](https://github.com/Ortes).

--- a/lib/src/material/material_desktop_controls.dart
+++ b/lib/src/material/material_desktop_controls.dart
@@ -75,6 +75,11 @@ class _MaterialDesktopControlsState extends State<MaterialDesktopControls>
       if (chewieController.isFullScreen) {
         _onExpandCollapse();
       }
+    } else if (event is KeyDownEvent &&
+        event.logicalKey == LogicalKeyboardKey.keyF) {
+      if (chewieController.allowFullScreen) {
+        _onExpandCollapse();
+      }
     }
   }
 

--- a/test/keyboard_fullscreen_toggle_test.dart
+++ b/test/keyboard_fullscreen_toggle_test.dart
@@ -1,0 +1,60 @@
+import 'package:chewie/chewie.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:video_player/video_player.dart';
+
+const _src =
+    'https://assets.mixkit.co/videos/preview/mixkit-spinning-around-the-earth-29351-large.mp4';
+
+ChewieController _controller({bool allowFullScreen = true}) {
+  return ChewieController(
+    videoPlayerController: VideoPlayerController.networkUrl(Uri.parse(_src)),
+    autoPlay: false,
+    looping: false,
+    allowFullScreen: allowFullScreen,
+    customControls: const MaterialDesktopControls(),
+  );
+}
+
+Future<void> _pumpPlayer(
+  WidgetTester tester,
+  ChewieController controller,
+) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(body: Chewie(controller: controller)),
+    ),
+  );
+  await tester.pump();
+}
+
+Future<void> _pressF(WidgetTester tester) async {
+  await tester.sendKeyEvent(LogicalKeyboardKey.keyF);
+  await tester.pump();
+  await tester.pump(const Duration(seconds: 1));
+}
+
+void main() {
+  testWidgets('F key toggles fullscreen on and off', (tester) async {
+    final controller = _controller();
+    await _pumpPlayer(tester, controller);
+    expect(controller.isFullScreen, isFalse);
+
+    await _pressF(tester);
+    expect(controller.isFullScreen, isTrue);
+
+    await _pressF(tester);
+    expect(controller.isFullScreen, isFalse);
+  });
+
+  testWidgets('F key does nothing when allowFullScreen is false', (
+    tester,
+  ) async {
+    final controller = _controller(allowFullScreen: false);
+    await _pumpPlayer(tester, controller);
+
+    await _pressF(tester);
+    expect(controller.isFullScreen, isFalse);
+  });
+}


### PR DESCRIPTION
## What

Adds an `F` keyboard shortcut on the desktop controls (`MaterialDesktopControls`) that **toggles** fullscreen — enters if windowed, exits if fullscreen. This complements the existing `Esc` shortcut (which only exits) and matches the convention of most desktop video players (YouTube, VLC, mpv…).

## How

- One extra branch in `_MaterialDesktopControlsState._handleKeyPress` for `LogicalKeyboardKey.keyF`, calling the existing `_onExpandCollapse()` (which already drives `ChewieController.toggleFullScreen()`).
- Gated by `chewieController.allowFullScreen`, so it's a no-op when fullscreen is disabled.
- Keyboard shortcuts are desktop-only by construction (`AdaptiveControls` routes desktop/web platforms to `MaterialDesktopControls`), consistent with the existing space/arrow/Esc shortcuts.

## Tests

`test/keyboard_fullscreen_toggle_test.dart` covers toggling fullscreen on then off with repeated `F` presses, and that `F` is a no-op when `allowFullScreen: false`.

`dart format`, `flutter analyze lib`, and the full `flutter test` suite (with `--test-randomize-ordering-seed random`) are clean.