### PR TITLE
feat: show a hover-time indicator on the progress bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [Unreleased]
+* ⏱️ [#956](https://github.com/fluttercommunity/chewie/pull/956): Show a hover-time indicator on the Material progress bar: while the pointer hovers or drags the bar, a pill displays the timecode at that position, so it is clear where a click will seek to. Driven by hover events, so touch behaviour is unchanged. Thanks [Ortes](https://github.com/Ortes).
+
 ## [1.15.0]
 * 🌐 [#946](https://github.com/fluttercommunity/chewie/pull/946): Web: enter the browser's native (OS-level) fullscreen via the Fullscreen API instead of only expanding the Flutter view inside the browser window. Pressing Escape to leave browser fullscreen also exits Chewie's fullscreen. Controlled by the new `ChewieController.useNativeFullScreenOnWeb` flag (defaults to `true`; no effect on non-web platforms). Thanks [Ortes](https://github.com/Ortes).
 * 🖱️ [#950](https://github.com/fluttercommunity/chewie/pull/950): Show click cursor on hover over Material controls and progress bar. Thanks [Ortes](https://github.com/Ortes).

--- a/lib/src/progress_bar.dart
+++ b/lib/src/progress_bar.dart
@@ -47,12 +47,27 @@ class _VideoProgressBarState extends State<VideoProgressBar> {
   Offset? _latestDraggableOffset;
   Offset? _latestHoverOffset;
 
+  final LayerLink _indicatorLink = LayerLink();
+  final OverlayPortalController _indicatorPortal = OverlayPortalController();
+
   VideoPlayerController get controller => widget.controller;
 
   /// The pointer position that drives the hover-time indicator. A drag in
   /// progress takes priority over a plain hover; `null` when the pointer is
   /// away from the bar.
   Offset? get _indicatorOffset => _latestDraggableOffset ?? _latestHoverOffset;
+
+  /// Shows or hides the overlay-based time indicator to match
+  /// [_indicatorOffset]. Must be called from event handlers, not from build.
+  void _syncIndicatorVisibility() {
+    final bool shouldShow =
+        _indicatorOffset != null && controller.value.isInitialized;
+    if (shouldShow && !_indicatorPortal.isShowing) {
+      _indicatorPortal.show();
+    } else if (!shouldShow && _indicatorPortal.isShowing) {
+      _indicatorPortal.hide();
+    }
+  }
 
   @override
   void initState() {
@@ -89,72 +104,82 @@ class _VideoProgressBarState extends State<VideoProgressBar> {
       return child;
     }
 
-    return GestureDetector(
-      onHorizontalDragStart: (DragStartDetails details) {
-        if (!controller.value.isInitialized) {
-          return;
-        }
-        _controllerWasPlaying = controller.value.isPlaying;
-        if (_controllerWasPlaying) {
-          controller.pause();
-        }
+    return OverlayPortal(
+      controller: _indicatorPortal,
+      overlayChildBuilder: _buildHoverTimeIndicator,
+      child: CompositedTransformTarget(
+        link: _indicatorLink,
+        child: GestureDetector(
+          onHorizontalDragStart: (DragStartDetails details) {
+            if (!controller.value.isInitialized) {
+              return;
+            }
+            _controllerWasPlaying = controller.value.isPlaying;
+            if (_controllerWasPlaying) {
+              controller.pause();
+            }
 
-        widget.onDragStart?.call();
-      },
-      onHorizontalDragUpdate: (DragUpdateDetails details) {
-        if (!controller.value.isInitialized) {
-          return;
-        }
-        _latestDraggableOffset = details.globalPosition;
-        listener();
+            widget.onDragStart?.call();
+          },
+          onHorizontalDragUpdate: (DragUpdateDetails details) {
+            if (!controller.value.isInitialized) {
+              return;
+            }
+            _latestDraggableOffset = details.globalPosition;
+            _syncIndicatorVisibility();
+            listener();
 
-        widget.onDragUpdate?.call();
-      },
-      onHorizontalDragEnd: (DragEndDetails details) {
-        if (_controllerWasPlaying) {
-          controller.play();
-        }
+            widget.onDragUpdate?.call();
+          },
+          onHorizontalDragEnd: (DragEndDetails details) {
+            if (_controllerWasPlaying) {
+              controller.play();
+            }
 
-        if (_latestDraggableOffset != null) {
-          _seekToRelativePosition(_latestDraggableOffset!);
-          _latestDraggableOffset = null;
-        }
+            if (_latestDraggableOffset != null) {
+              _seekToRelativePosition(_latestDraggableOffset!);
+              _latestDraggableOffset = null;
+            }
+            _syncIndicatorVisibility();
 
-        widget.onDragEnd?.call();
-      },
-      onTapDown: (TapDownDetails details) {
-        if (!controller.value.isInitialized) {
-          return;
-        }
-        _seekToRelativePosition(details.globalPosition);
-      },
-      child: MouseRegion(
-        cursor: SystemMouseCursors.click,
-        onHover: (PointerHoverEvent event) {
-          if (!controller.value.isInitialized) {
-            return;
-          }
-          setState(() => _latestHoverOffset = event.position);
-        },
-        onExit: (PointerExitEvent event) {
-          if (_latestHoverOffset == null) {
-            return;
-          }
-          setState(() => _latestHoverOffset = null);
-        },
-        child: Stack(
-          clipBehavior: Clip.none,
-          children: [child, _buildHoverTimeIndicator(context)],
+            widget.onDragEnd?.call();
+          },
+          onTapDown: (TapDownDetails details) {
+            if (!controller.value.isInitialized) {
+              return;
+            }
+            _seekToRelativePosition(details.globalPosition);
+          },
+          child: MouseRegion(
+            cursor: SystemMouseCursors.click,
+            onHover: (PointerHoverEvent event) {
+              if (!controller.value.isInitialized) {
+                return;
+              }
+              setState(() => _latestHoverOffset = event.position);
+              _syncIndicatorVisibility();
+            },
+            onExit: (PointerExitEvent event) {
+              if (_latestHoverOffset == null) {
+                return;
+              }
+              setState(() => _latestHoverOffset = null);
+              _syncIndicatorVisibility();
+            },
+            child: child,
+          ),
         ),
       ),
     );
   }
 
   /// A floating pill that shows the timecode under the pointer while it hovers
-  /// (or drags) the bar. Renders nothing when the pointer is away, the video is
-  /// not ready yet, or the bar hasn't been laid out — so touch devices, which
-  /// never emit hover events, are unaffected.
-  Widget _buildHoverTimeIndicator(BuildContext context) {
+  /// (or drags) the bar. Rendered through an [OverlayPortal] so ancestor clips
+  /// (e.g. the rounded, blurred cupertino bottom bar) cannot cut it off; a
+  /// [CompositedTransformFollower] keeps it glued to the bar. Renders nothing
+  /// when the pointer is away, the video is not ready yet, or the bar hasn't
+  /// been laid out.
+  Widget _buildHoverTimeIndicator(BuildContext overlayContext) {
     final Offset? offset = _indicatorOffset;
     final Duration duration = controller.value.duration;
     if (offset == null ||
@@ -170,37 +195,26 @@ class _VideoProgressBarState extends State<VideoProgressBar> {
       return const SizedBox.shrink();
     }
 
+    final Size barSize = renderObject.size;
     final double relative =
-        (renderObject.globalToLocal(offset).dx / renderObject.size.width).clamp(
-          0.0,
-          1.0,
-        );
+        (renderObject.globalToLocal(offset).dx / barSize.width).clamp(0.0, 1.0);
     final String label = formatDuration(duration * relative);
 
-    return Positioned.fill(
-      child: IgnorePointer(
-        child: LayoutBuilder(
-          builder: (context, constraints) {
-            final double width = constraints.maxWidth;
-            final double height = constraints.maxHeight;
-            if (!width.isFinite || !height.isFinite) {
-              return const SizedBox.shrink();
-            }
-            final double barTop = height / 2 - widget.barHeight / 2;
-            return Stack(
-              clipBehavior: Clip.none,
-              children: [
-                Positioned(
-                  left: (relative * width).clamp(0.0, width),
-                  bottom: height - barTop + 6.0,
-                  child: FractionalTranslation(
-                    translation: const Offset(-0.5, 0.0),
-                    child: _HoverTimeLabel(text: label),
-                  ),
-                ),
-              ],
-            );
-          },
+    final double barTop = barSize.height / 2 - widget.barHeight / 2;
+
+    return IgnorePointer(
+      child: CompositedTransformFollower(
+        link: _indicatorLink,
+        showWhenUnlinked: false,
+        offset: Offset(relative * barSize.width, barTop - 6.0),
+        child: Align(
+          alignment: Alignment.topLeft,
+          child: FractionalTranslation(
+            // Center the pill on the pointer and place its bottom edge just
+            // above the painted bar.
+            translation: const Offset(-0.5, -1.0),
+            child: _HoverTimeLabel(text: label),
+          ),
         ),
       ),
     );

--- a/lib/src/progress_bar.dart
+++ b/lib/src/progress_bar.dart
@@ -144,10 +144,7 @@ class _VideoProgressBarState extends State<VideoProgressBar> {
         },
         child: Stack(
           clipBehavior: Clip.none,
-          children: [
-            child,
-            _buildHoverTimeIndicator(context),
-          ],
+          children: [child, _buildHoverTimeIndicator(context)],
         ),
       ),
     );
@@ -174,8 +171,10 @@ class _VideoProgressBarState extends State<VideoProgressBar> {
     }
 
     final double relative =
-        (renderObject.globalToLocal(offset).dx / renderObject.size.width)
-            .clamp(0.0, 1.0);
+        (renderObject.globalToLocal(offset).dx / renderObject.size.width).clamp(
+          0.0,
+          1.0,
+        );
     final String label = formatDuration(duration * relative);
 
     return Positioned.fill(

--- a/lib/src/progress_bar.dart
+++ b/lib/src/progress_bar.dart
@@ -1,4 +1,6 @@
 import 'package:chewie/chewie.dart';
+import 'package:chewie/src/helpers/utils.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:video_player/video_player.dart';
 
@@ -43,8 +45,14 @@ class _VideoProgressBarState extends State<VideoProgressBar> {
   bool _controllerWasPlaying = false;
 
   Offset? _latestDraggableOffset;
+  Offset? _latestHoverOffset;
 
   VideoPlayerController get controller => widget.controller;
+
+  /// The pointer position that drives the hover-time indicator. A drag in
+  /// progress takes priority over a plain hover; `null` when the pointer is
+  /// away from the bar.
+  Offset? get _indicatorOffset => _latestDraggableOffset ?? _latestHoverOffset;
 
   @override
   void initState() {
@@ -77,50 +85,184 @@ class _VideoProgressBarState extends State<VideoProgressBar> {
       ),
     );
 
-    return widget.draggableProgressBar
-        ? GestureDetector(
-            onHorizontalDragStart: (DragStartDetails details) {
-              if (!controller.value.isInitialized) {
-                return;
-              }
-              _controllerWasPlaying = controller.value.isPlaying;
-              if (_controllerWasPlaying) {
-                controller.pause();
-              }
+    if (!widget.draggableProgressBar) {
+      return child;
+    }
 
-              widget.onDragStart?.call();
-            },
-            onHorizontalDragUpdate: (DragUpdateDetails details) {
-              if (!controller.value.isInitialized) {
-                return;
-              }
-              _latestDraggableOffset = details.globalPosition;
-              listener();
+    return GestureDetector(
+      onHorizontalDragStart: (DragStartDetails details) {
+        if (!controller.value.isInitialized) {
+          return;
+        }
+        _controllerWasPlaying = controller.value.isPlaying;
+        if (_controllerWasPlaying) {
+          controller.pause();
+        }
 
-              widget.onDragUpdate?.call();
-            },
-            onHorizontalDragEnd: (DragEndDetails details) {
-              if (_controllerWasPlaying) {
-                controller.play();
-              }
+        widget.onDragStart?.call();
+      },
+      onHorizontalDragUpdate: (DragUpdateDetails details) {
+        if (!controller.value.isInitialized) {
+          return;
+        }
+        _latestDraggableOffset = details.globalPosition;
+        listener();
 
-              if (_latestDraggableOffset != null) {
-                _seekToRelativePosition(_latestDraggableOffset!);
-                _latestDraggableOffset = null;
-              }
+        widget.onDragUpdate?.call();
+      },
+      onHorizontalDragEnd: (DragEndDetails details) {
+        if (_controllerWasPlaying) {
+          controller.play();
+        }
 
-              widget.onDragEnd?.call();
-            },
-            onTapDown: (TapDownDetails details) {
-              if (!controller.value.isInitialized) {
-                return;
-              }
-              _seekToRelativePosition(details.globalPosition);
-            },
-            child: MouseRegion(cursor: SystemMouseCursors.click, child: child),
-          )
-        : child;
+        if (_latestDraggableOffset != null) {
+          _seekToRelativePosition(_latestDraggableOffset!);
+          _latestDraggableOffset = null;
+        }
+
+        widget.onDragEnd?.call();
+      },
+      onTapDown: (TapDownDetails details) {
+        if (!controller.value.isInitialized) {
+          return;
+        }
+        _seekToRelativePosition(details.globalPosition);
+      },
+      child: MouseRegion(
+        cursor: SystemMouseCursors.click,
+        onHover: (PointerHoverEvent event) {
+          if (!controller.value.isInitialized) {
+            return;
+          }
+          setState(() => _latestHoverOffset = event.position);
+        },
+        onExit: (PointerExitEvent event) {
+          if (_latestHoverOffset == null) {
+            return;
+          }
+          setState(() => _latestHoverOffset = null);
+        },
+        child: Stack(
+          clipBehavior: Clip.none,
+          children: [
+            child,
+            _buildHoverTimeIndicator(context),
+          ],
+        ),
+      ),
+    );
   }
+
+  /// A floating pill that shows the timecode under the pointer while it hovers
+  /// (or drags) the bar. Renders nothing when the pointer is away, the video is
+  /// not ready yet, or the bar hasn't been laid out — so touch devices, which
+  /// never emit hover events, are unaffected.
+  Widget _buildHoverTimeIndicator(BuildContext context) {
+    final Offset? offset = _indicatorOffset;
+    final Duration duration = controller.value.duration;
+    if (offset == null ||
+        !controller.value.isInitialized ||
+        duration.inMilliseconds <= 0) {
+      return const SizedBox.shrink();
+    }
+
+    final renderObject = context.findRenderObject();
+    if (renderObject is! RenderBox ||
+        !renderObject.hasSize ||
+        renderObject.size.width <= 0) {
+      return const SizedBox.shrink();
+    }
+
+    final double relative =
+        (renderObject.globalToLocal(offset).dx / renderObject.size.width)
+            .clamp(0.0, 1.0);
+    final String label = formatDuration(duration * relative);
+
+    return Positioned.fill(
+      child: IgnorePointer(
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            final double width = constraints.maxWidth;
+            final double height = constraints.maxHeight;
+            if (!width.isFinite || !height.isFinite) {
+              return const SizedBox.shrink();
+            }
+            final double barTop = height / 2 - widget.barHeight / 2;
+            return Stack(
+              clipBehavior: Clip.none,
+              children: [
+                Positioned(
+                  left: (relative * width).clamp(0.0, width),
+                  bottom: height - barTop + 6.0,
+                  child: FractionalTranslation(
+                    translation: const Offset(-0.5, 0.0),
+                    child: _HoverTimeLabel(text: label),
+                  ),
+                ),
+              ],
+            );
+          },
+        ),
+      ),
+    );
+  }
+}
+
+/// A small dark pill with a downward caret, showing the hovered timecode above
+/// the progress bar.
+class _HoverTimeLabel extends StatelessWidget {
+  const _HoverTimeLabel({required this.text});
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Container(
+          padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 4.0),
+          decoration: BoxDecoration(
+            color: Colors.black.withValues(alpha: 0.8),
+            borderRadius: BorderRadius.circular(6.0),
+          ),
+          child: Text(
+            text,
+            style: const TextStyle(
+              color: Colors.white,
+              fontSize: 13.0,
+              fontWeight: FontWeight.w600,
+              fontFeatures: [FontFeature.tabularFigures()],
+            ),
+          ),
+        ),
+        CustomPaint(
+          size: const Size(10.0, 5.0),
+          painter: _CaretPainter(color: Colors.black.withValues(alpha: 0.8)),
+        ),
+      ],
+    );
+  }
+}
+
+/// Draws the downward-pointing caret beneath [_HoverTimeLabel].
+class _CaretPainter extends CustomPainter {
+  _CaretPainter({required this.color});
+
+  final Color color;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final Path path = Path()
+      ..moveTo(0, 0)
+      ..lineTo(size.width, 0)
+      ..lineTo(size.width / 2, size.height)
+      ..close();
+    canvas.drawPath(path, Paint()..color = color);
+  }
+
+  @override
+  bool shouldRepaint(_CaretPainter oldDelegate) => oldDelegate.color != color;
 }
 
 class StaticProgressBar extends StatelessWidget {

--- a/test/progress_bar_hover_indicator_test.dart
+++ b/test/progress_bar_hover_indicator_test.dart
@@ -1,0 +1,100 @@
+import 'package:chewie/src/progress_bar.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:video_player/video_player.dart';
+
+class _FakeVideoPlayerController extends Fake
+    with ChangeNotifier
+    implements VideoPlayerController {
+  @override
+  VideoPlayerValue value = const VideoPlayerValue(
+    duration: Duration(minutes: 4),
+    isInitialized: true,
+  );
+
+  @override
+  Future<void> play() async {}
+
+  @override
+  Future<void> pause() async {}
+
+  @override
+  Future<void> seekTo(Duration position) async {}
+
+  @override
+  Future<void> dispose() async {
+    super.dispose();
+  }
+}
+
+void main() {
+  testWidgets('scrub time indicator escapes ancestor clips (iOS bottom bar)', (
+    WidgetTester tester,
+  ) async {
+    final controller = _FakeVideoPlayerController();
+
+    // Mimics the cupertino bottom bar: a short, clipped strip. Before the
+    // overlay-based indicator, the pill was cut off by this ClipRRect.
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(10.0),
+              child: SizedBox(
+                width: 300,
+                height: 30,
+                child: VideoProgressBar(
+                  controller,
+                  barHeight: 5,
+                  handleHeight: 6,
+                  drawShadow: true,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final barRect = tester.getRect(find.byType(VideoProgressBar));
+
+    // Scrub with a touch drag, like on iOS.
+    final gesture = await tester.startGesture(barRect.center);
+    // The first move settles the gesture arena (touch slop); the second
+    // one delivers a drag update.
+    await gesture.moveBy(const Offset(20, 0));
+    await tester.pump();
+    await gesture.moveBy(const Offset(10, 0));
+    await tester.pump();
+
+    final pill = find.textContaining(':');
+    expect(pill, findsOneWidget);
+
+    // The pill must not be painted inside the clipping bar. OverlayPortal
+    // keeps the overlay child in the element tree but reparents its render
+    // object into the Overlay, so check the render-object ancestry.
+    final RenderObject clipRender = tester.renderObject(find.byType(ClipRRect));
+    RenderObject? node = tester.renderObject(pill);
+    while (node != null) {
+      expect(node, isNot(same(clipRender)));
+      node = node.parent;
+    }
+
+    // It sits fully above the painted bar, outside the clipped strip.
+    final pillRect = tester.getRect(pill);
+    expect(pillRect.bottom, lessThan(barRect.top));
+
+    // And it stays horizontally glued to the pointer position.
+    expect(
+      pillRect.center.dx,
+      moreOrLessEquals(barRect.center.dx + 30, epsilon: 1.0),
+    );
+
+    await gesture.up();
+    await tester.pump();
+
+    // Released: the indicator goes away.
+    expect(find.textContaining(':'), findsNothing);
+  });
+}


### PR DESCRIPTION
### Description

Adds a small floating time indicator to the Material progress bar. While the pointer hovers (or drags) the bar, a pill shows the timecode at that position, so the user can see exactly where a click or seek will jump to — the behaviour people expect from YouTube/Netflix-style scrubbers.

The pill is rendered as an overlay above the bar and follows the pointer horizontally, clamped to the bar's width, with a small caret pointing at the exact spot. It uses the existing `formatDuration` helper, so it matches the `position / duration` label already shown in the controls.

### Behaviour

- Only shows once the video is initialized and its duration is known.
- Driven by hover events, so it never appears on touch devices (which don't emit hover) — mobile behaviour is unchanged. It does also track an in-progress drag, which gives touch users seek feedback while scrubbing.
- Purely additive and self-contained in `progress_bar.dart`; no public API changes.

### Notes

Scoped intentionally to the hover-time readout only — it does not set the hover cursor (that is handled separately in #950).
