### PR TITLE
feat: YouTube-style chapters on the progress bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [Unreleased]
+* ✨ [#959](https://github.com/fluttercommunity/chewie/pull/959): YouTube-style chapters on the progress bar. Pass `ChewieController.chapters` to split the bar into chapter segments and show the hovered/scrubbed chapter title above it. Thanks [Ortes](https://github.com/Ortes).
+
 ## [1.15.0]
 * 🌐 [#946](https://github.com/fluttercommunity/chewie/pull/946): Web: enter the browser's native (OS-level) fullscreen via the Fullscreen API instead of only expanding the Flutter view inside the browser window. Pressing Escape to leave browser fullscreen also exits Chewie's fullscreen. Controlled by the new `ChewieController.useNativeFullScreenOnWeb` flag (defaults to `true`; no effect on non-web platforms). Thanks [Ortes](https://github.com/Ortes).
 * 🖱️ [#950](https://github.com/fluttercommunity/chewie/pull/950): Show click cursor on hover over Material controls and progress bar. Thanks [Ortes](https://github.com/Ortes).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-* ✨ [#959](https://github.com/fluttercommunity/chewie/pull/959): YouTube-style chapters on the progress bar. Pass `ChewieController.chapters` to split the bar into chapter segments and show the hovered/scrubbed chapter title above it. Thanks [Ortes](https://github.com/Ortes).
+* ⬆️ [#959](https://github.com/fluttercommunity/chewie/pull/959): Add YouTube-style chapters to the progress bar. Pass `ChewieController.chapters` to split the bar into chapter segments and show the hovered/scrubbed chapter title above it. Thanks [Ortes](https://github.com/Ortes).
 
 ## [1.15.0]
 * 🌐 [#946](https://github.com/fluttercommunity/chewie/pull/946): Web: enter the browser's native (OS-level) fullscreen via the Fullscreen API instead of only expanding the Flutter view inside the browser window. Pressing Escape to leave browser fullscreen also exits Chewie's fullscreen. Controlled by the new `ChewieController.useNativeFullScreenOnWeb` flag (defaults to `true`; no effect on non-web platforms). Thanks [Ortes](https://github.com/Ortes).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [Unreleased]
+* ⬆️ [#959](https://github.com/fluttercommunity/chewie/pull/959): Add YouTube-style chapters to the progress bar. Pass `ChewieController.chapters` to split the bar into chapter segments and show the hovered/scrubbed chapter title above it. Thanks [Ortes](https://github.com/Ortes).
+
 ## [1.16.1]
 * ✨ [#962](https://github.com/fluttercommunity/chewie/pull/962): Expose `showPlayButton` on `ChewieController` to allow showing or hiding the center play button. Thanks [ibrahim-iqbal](https://github.com/ibrahim-iqbal).
 

--- a/README.md
+++ b/README.md
@@ -21,11 +21,12 @@ Chewie uses the `video_player` under the hood and wraps it in a friendly Materia
 5.  🕹️ [Using it](#%EF%B8%8F-using-it)
 6.  ⚙️ [Options](#%EF%B8%8F-options)
 7.  🔡 [Subtitles](#-subtitles)
-8.  🧪 [Example](#-example)
-9.  ⏪ [Migrating from Chewie < 0.9.0](#-migrating-from-chewie--090)
-10. 🗺️ [Roadmap](#%EF%B8%8F-roadmap)
-11. ⚠️ [Android warning](#%EF%B8%8F-android-warning)
-12. 📱 [iOS warning](#-ios-warning)
+8.  🔖 [Chapters](#-chapters)
+9.  🧪 [Example](#-example)
+10. ⏪ [Migrating from Chewie < 0.9.0](#-migrating-from-chewie--090)
+11. 🗺️ [Roadmap](#%EF%B8%8F-roadmap)
+12. ⚠️ [Android warning](#%EF%B8%8F-android-warning)
+13. 📱 [iOS warning](#-ios-warning)
 
 
 ## 🚨 IMPORTANT!!! (READ THIS FIRST)
@@ -280,6 +281,23 @@ subtitleBuilder: (context, subtitle) => Container(
   ),
 ),
 ```
+
+## 🔖 Chapters
+
+Pass a list of `ChewieChapter`s, sorted by ascending start time, to draw the progress bar as YouTube-style chapter segments. Hovering or scrubbing the bar shows the pointed chapter's title above it:
+
+```dart
+final chewieController = ChewieController(
+  videoPlayerController: videoPlayerController,
+  chapters: const [
+    ChewieChapter(title: 'Intro', start: Duration.zero),
+    ChewieChapter(title: 'First topic', start: Duration(minutes: 1)),
+    ChewieChapter(title: 'Conclusion', start: Duration(minutes: 4)),
+  ],
+);
+```
+
+When `chapters` is empty (the default), the progress bar is rendered as a single continuous segment, as before.
 
 ## 🧪 Example
 

--- a/lib/src/chewie_player.dart
+++ b/lib/src/chewie_player.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:chewie/src/chewie_progress_colors.dart';
+import 'package:chewie/src/models/chewie_chapter.dart';
 import 'web_fullscreen.dart';
 import 'package:chewie/src/models/option_item.dart';
 import 'package:chewie/src/models/options_translation.dart';
@@ -364,6 +365,7 @@ class ChewieController extends ChangeNotifier {
     this.hideControlsTimer = defaultHideControlsTimer,
     this.controlsSafeAreaMinimum = EdgeInsets.zero,
     this.pauseOnBackgroundTap = false,
+    this.chapters = const [],
   }) : assert(
          playbackSpeeds.every((speed) => speed > 0),
          'The playbackSpeeds values must all be greater than 0',
@@ -425,6 +427,7 @@ class ChewieController extends ChangeNotifier {
     )?
     routePageBuilder,
     bool? pauseOnBackgroundTap,
+    List<ChewieChapter>? chapters,
   }) {
     return ChewieController(
       draggableProgressBar: draggableProgressBar ?? this.draggableProgressBar,
@@ -492,6 +495,7 @@ class ChewieController extends ChangeNotifier {
       progressIndicatorDelay:
           progressIndicatorDelay ?? this.progressIndicatorDelay,
       pauseOnBackgroundTap: pauseOnBackgroundTap ?? this.pauseOnBackgroundTap,
+      chapters: chapters ?? this.chapters,
     );
   }
 
@@ -684,6 +688,11 @@ class ChewieController extends ChangeNotifier {
 
   /// Defines if the player should pause when the background is tapped
   final bool pauseOnBackgroundTap;
+
+  /// Chapters of the video, sorted by ascending start time.
+  /// When non-empty, the progress bar is split into chapter segments and the
+  /// hovered/scrubbed chapter title is displayed above the bar.
+  final List<ChewieChapter> chapters;
 
   static ChewieController of(BuildContext context) {
     final chewieControllerProvider = context

--- a/lib/src/chewie_player.dart
+++ b/lib/src/chewie_player.dart
@@ -370,6 +370,10 @@ class ChewieController extends ChangeNotifier {
   }) : assert(
          playbackSpeeds.every((speed) => speed > 0),
          'The playbackSpeeds values must all be greater than 0',
+       ),
+       assert(
+         _chaptersAreSortedByStart(chapters),
+         'The chapters must be sorted by ascending start time',
        ) {
     _initialize();
   }
@@ -700,6 +704,15 @@ class ChewieController extends ChangeNotifier {
   /// When non-empty, the progress bar is split into chapter segments and the
   /// hovered/scrubbed chapter title is displayed above the bar.
   final List<ChewieChapter> chapters;
+
+  static bool _chaptersAreSortedByStart(List<ChewieChapter> chapters) {
+    for (var i = 1; i < chapters.length; i++) {
+      if (chapters[i].start < chapters[i - 1].start) {
+        return false;
+      }
+    }
+    return true;
+  }
 
   static ChewieController of(BuildContext context) {
     final chewieControllerProvider = context

--- a/lib/src/chewie_player.dart
+++ b/lib/src/chewie_player.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:chewie/src/chewie_progress_colors.dart';
+import 'package:chewie/src/models/chewie_chapter.dart';
 import 'web_fullscreen.dart';
 import 'package:chewie/src/models/option_item.dart';
 import 'package:chewie/src/models/options_translation.dart';
@@ -365,6 +366,7 @@ class ChewieController extends ChangeNotifier {
     this.hideControlsTimer = defaultHideControlsTimer,
     this.controlsSafeAreaMinimum = EdgeInsets.zero,
     this.pauseOnBackgroundTap = false,
+    this.chapters = const [],
   }) : assert(
          playbackSpeeds.every((speed) => speed > 0),
          'The playbackSpeeds values must all be greater than 0',
@@ -427,6 +429,7 @@ class ChewieController extends ChangeNotifier {
     )?
     routePageBuilder,
     bool? pauseOnBackgroundTap,
+    List<ChewieChapter>? chapters,
   }) {
     return ChewieController(
       draggableProgressBar: draggableProgressBar ?? this.draggableProgressBar,
@@ -495,6 +498,7 @@ class ChewieController extends ChangeNotifier {
       progressIndicatorDelay:
           progressIndicatorDelay ?? this.progressIndicatorDelay,
       pauseOnBackgroundTap: pauseOnBackgroundTap ?? this.pauseOnBackgroundTap,
+      chapters: chapters ?? this.chapters,
     );
   }
 
@@ -691,6 +695,11 @@ class ChewieController extends ChangeNotifier {
 
   /// Defines if the player should pause when the background is tapped
   final bool pauseOnBackgroundTap;
+
+  /// Chapters of the video, sorted by ascending start time.
+  /// When non-empty, the progress bar is split into chapter segments and the
+  /// hovered/scrubbed chapter title is displayed above the bar.
+  final List<ChewieChapter> chapters;
 
   static ChewieController of(BuildContext context) {
     final chewieControllerProvider = context

--- a/lib/src/chewie_player.dart
+++ b/lib/src/chewie_player.dart
@@ -369,6 +369,10 @@ class ChewieController extends ChangeNotifier {
   }) : assert(
          playbackSpeeds.every((speed) => speed > 0),
          'The playbackSpeeds values must all be greater than 0',
+       ),
+       assert(
+         _chaptersAreSortedByStart(chapters),
+         'The chapters must be sorted by ascending start time',
        ) {
     _initialize();
   }
@@ -693,6 +697,15 @@ class ChewieController extends ChangeNotifier {
   /// When non-empty, the progress bar is split into chapter segments and the
   /// hovered/scrubbed chapter title is displayed above the bar.
   final List<ChewieChapter> chapters;
+
+  static bool _chaptersAreSortedByStart(List<ChewieChapter> chapters) {
+    for (var i = 1; i < chapters.length; i++) {
+      if (chapters[i].start < chapters[i - 1].start) {
+        return false;
+      }
+    }
+    return true;
+  }
 
   static ChewieController of(BuildContext context) {
     final chewieControllerProvider = context

--- a/lib/src/cupertino/cupertino_controls.dart
+++ b/lib/src/cupertino/cupertino_controls.dart
@@ -623,6 +623,7 @@ class _CupertinoControlsState extends State<CupertinoControls>
         padding: const EdgeInsets.only(right: 12.0),
         child: CupertinoVideoProgressBar(
           controller,
+          chapters: chewieController.chapters,
           onDragStart: () {
             setState(() {
               _dragging = true;

--- a/lib/src/cupertino/cupertino_progress_bar.dart
+++ b/lib/src/cupertino/cupertino_progress_bar.dart
@@ -17,7 +17,13 @@ class CupertinoVideoProgressBar extends StatelessWidget {
     this.chapters = const [],
   }) : colors = colors ?? ChewieProgressColors();
 
+  /// The chapters of the video, sorted by ascending start time.
+  ///
+  /// When non-empty, the bar is painted as one segment per chapter and the
+  /// pointed chapter's title is shown above the bar while hovering or
+  /// scrubbing.
   final List<ChewieChapter> chapters;
+
   final VideoPlayerController controller;
   final ChewieProgressColors colors;
   final Function()? onDragStart;

--- a/lib/src/cupertino/cupertino_progress_bar.dart
+++ b/lib/src/cupertino/cupertino_progress_bar.dart
@@ -1,4 +1,5 @@
 import 'package:chewie/src/chewie_progress_colors.dart';
+import 'package:chewie/src/models/chewie_chapter.dart';
 import 'package:chewie/src/progress_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
@@ -13,8 +14,10 @@ class CupertinoVideoProgressBar extends StatelessWidget {
     this.onDragUpdate,
     super.key,
     this.draggableProgressBar = true,
+    this.chapters = const [],
   }) : colors = colors ?? ChewieProgressColors();
 
+  final List<ChewieChapter> chapters;
   final VideoPlayerController controller;
   final ChewieProgressColors colors;
   final Function()? onDragStart;
@@ -34,6 +37,7 @@ class CupertinoVideoProgressBar extends StatelessWidget {
       onDragStart: onDragStart,
       onDragUpdate: onDragUpdate,
       draggableProgressBar: draggableProgressBar,
+      chapters: chapters,
     );
   }
 }

--- a/lib/src/material/material_controls.dart
+++ b/lib/src/material/material_controls.dart
@@ -632,6 +632,7 @@ class _MaterialControlsState extends State<MaterialControls>
     return Expanded(
       child: MaterialVideoProgressBar(
         controller,
+        chapters: chewieController.chapters,
         onDragStart: () {
           setState(() {
             _dragging = true;

--- a/lib/src/material/material_desktop_controls.dart
+++ b/lib/src/material/material_desktop_controls.dart
@@ -593,6 +593,7 @@ class _MaterialDesktopControlsState extends State<MaterialDesktopControls>
     return Expanded(
       child: MaterialVideoProgressBar(
         controller,
+        chapters: chewieController.chapters,
         onDragStart: () {
           setState(() {
             _dragging = true;

--- a/lib/src/material/material_progress_bar.dart
+++ b/lib/src/material/material_progress_bar.dart
@@ -19,7 +19,13 @@ class MaterialVideoProgressBar extends StatelessWidget {
     this.chapters = const [],
   }) : colors = colors ?? ChewieProgressColors();
 
+  /// The chapters of the video, sorted by ascending start time.
+  ///
+  /// When non-empty, the bar is painted as one segment per chapter and the
+  /// pointed chapter's title is shown above the bar while hovering or
+  /// scrubbing.
   final List<ChewieChapter> chapters;
+
   final double height;
   final double barHeight;
   final double handleHeight;

--- a/lib/src/material/material_progress_bar.dart
+++ b/lib/src/material/material_progress_bar.dart
@@ -1,4 +1,5 @@
 import 'package:chewie/src/chewie_progress_colors.dart';
+import 'package:chewie/src/models/chewie_chapter.dart';
 import 'package:chewie/src/progress_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:video_player/video_player.dart';
@@ -15,8 +16,10 @@ class MaterialVideoProgressBar extends StatelessWidget {
     this.onDragUpdate,
     super.key,
     this.draggableProgressBar = true,
+    this.chapters = const [],
   }) : colors = colors ?? ChewieProgressColors();
 
+  final List<ChewieChapter> chapters;
   final double height;
   final double barHeight;
   final double handleHeight;
@@ -39,6 +42,7 @@ class MaterialVideoProgressBar extends StatelessWidget {
       onDragStart: onDragStart,
       onDragUpdate: onDragUpdate,
       draggableProgressBar: draggableProgressBar,
+      chapters: chapters,
     );
   }
 }

--- a/lib/src/models/chewie_chapter.dart
+++ b/lib/src/models/chewie_chapter.dart
@@ -1,6 +1,16 @@
+/// A named section of a video, used to split the progress bar into
+/// YouTube-style chapter segments.
+///
+/// Provide chapters to a video through [ChewieController.chapters], sorted by
+/// ascending [start] time. The first chapter usually starts at
+/// [Duration.zero].
 class ChewieChapter {
   const ChewieChapter({required this.title, required this.start});
 
+  /// The title displayed above the progress bar while the chapter is hovered
+  /// or scrubbed.
   final String title;
+
+  /// The position in the video at which this chapter begins.
   final Duration start;
 }

--- a/lib/src/models/chewie_chapter.dart
+++ b/lib/src/models/chewie_chapter.dart
@@ -1,0 +1,6 @@
+class ChewieChapter {
+  const ChewieChapter({required this.title, required this.start});
+
+  final String title;
+  final Duration start;
+}

--- a/lib/src/models/index.dart
+++ b/lib/src/models/index.dart
@@ -1,3 +1,4 @@
+export 'chewie_chapter.dart';
 export 'option_item.dart';
 export 'options_translation.dart';
 export 'subtitle_model.dart';

--- a/lib/src/progress_bar.dart
+++ b/lib/src/progress_bar.dart
@@ -167,10 +167,15 @@ class _VideoProgressBarState extends State<VideoProgressBar> {
         : child;
 
     if (widget.chapters.isEmpty) {
-      return interactive;
+      return widget.draggableProgressBar
+          ? MouseRegion(cursor: SystemMouseCursors.click, child: interactive)
+          : interactive;
     }
 
     return MouseRegion(
+      cursor: widget.draggableProgressBar
+          ? SystemMouseCursors.click
+          : MouseCursor.defer,
       onHover: (event) => setState(() => _hoverPosition = event.localPosition),
       onExit: (_) => setState(() => _hoverPosition = null),
       child: LayoutBuilder(

--- a/lib/src/progress_bar.dart
+++ b/lib/src/progress_bar.dart
@@ -28,6 +28,12 @@ class VideoProgressBar extends StatefulWidget {
   final double handleHeight;
   final bool drawShadow;
   final bool draggableProgressBar;
+
+  /// The chapters of the video, sorted by ascending start time.
+  ///
+  /// When non-empty, the bar is painted as one segment per chapter and the
+  /// pointed chapter's title is shown above the bar while hovering or
+  /// scrubbing.
   final List<ChewieChapter> chapters;
 
   @override
@@ -128,15 +134,10 @@ class _VideoProgressBarState extends State<VideoProgressBar> {
         : child;
 
     if (widget.chapters.isEmpty) {
-      return widget.draggableProgressBar
-          ? MouseRegion(cursor: SystemMouseCursors.click, child: interactive)
-          : interactive;
+      return interactive;
     }
 
     return MouseRegion(
-      cursor: widget.draggableProgressBar
-          ? SystemMouseCursors.click
-          : MouseCursor.defer,
       onHover: (event) => setState(() => _hoverPosition = event.localPosition),
       onExit: (_) => setState(() => _hoverPosition = null),
       child: LayoutBuilder(
@@ -231,6 +232,10 @@ class StaticProgressBar extends StatelessWidget {
   final double barHeight;
   final double handleHeight;
   final bool drawShadow;
+
+  /// The chapters of the video, sorted by ascending start time.
+  ///
+  /// When non-empty, the bar is painted as one segment per chapter.
   final List<ChewieChapter> chapters;
 
   @override

--- a/lib/src/progress_bar.dart
+++ b/lib/src/progress_bar.dart
@@ -28,6 +28,12 @@ class VideoProgressBar extends StatefulWidget {
   final double handleHeight;
   final bool drawShadow;
   final bool draggableProgressBar;
+
+  /// The chapters of the video, sorted by ascending start time.
+  ///
+  /// When non-empty, the bar is painted as one segment per chapter and the
+  /// pointed chapter's title is shown above the bar while hovering or
+  /// scrubbing.
   final List<ChewieChapter> chapters;
 
   @override
@@ -167,15 +173,10 @@ class _VideoProgressBarState extends State<VideoProgressBar> {
         : child;
 
     if (widget.chapters.isEmpty) {
-      return widget.draggableProgressBar
-          ? MouseRegion(cursor: SystemMouseCursors.click, child: interactive)
-          : interactive;
+      return interactive;
     }
 
     return MouseRegion(
-      cursor: widget.draggableProgressBar
-          ? SystemMouseCursors.click
-          : MouseCursor.defer,
       onHover: (event) => setState(() => _hoverPosition = event.localPosition),
       onExit: (_) => setState(() => _hoverPosition = null),
       child: LayoutBuilder(
@@ -276,6 +277,10 @@ class StaticProgressBar extends StatelessWidget {
   final double barHeight;
   final double handleHeight;
   final bool drawShadow;
+
+  /// The chapters of the video, sorted by ascending start time.
+  ///
+  /// When non-empty, the bar is painted as one segment per chapter.
   final List<ChewieChapter> chapters;
 
   @override

--- a/lib/src/progress_bar.dart
+++ b/lib/src/progress_bar.dart
@@ -1,4 +1,5 @@
 import 'package:chewie/chewie.dart';
+import 'package:chewie/src/helpers/utils.dart';
 import 'package:flutter/material.dart';
 import 'package:video_player/video_player.dart';
 
@@ -14,6 +15,7 @@ class VideoProgressBar extends StatefulWidget {
     required this.barHeight,
     required this.handleHeight,
     required this.drawShadow,
+    this.chapters = const [],
   }) : colors = colors ?? ChewieProgressColors();
 
   final VideoPlayerController controller;
@@ -26,6 +28,7 @@ class VideoProgressBar extends StatefulWidget {
   final double handleHeight;
   final bool drawShadow;
   final bool draggableProgressBar;
+  final List<ChewieChapter> chapters;
 
   @override
   // ignore: library_private_types_in_public_api
@@ -59,6 +62,8 @@ class _VideoProgressBarState extends State<VideoProgressBar> {
   /// Identifies the latest seek request so a stale one cannot clear the
   /// position requested by a newer one.
   int _latestSeekRequestId = 0;
+
+  Offset? _hoverPosition;
 
   VideoPlayerController get controller => widget.controller;
 
@@ -111,10 +116,11 @@ class _VideoProgressBarState extends State<VideoProgressBar> {
         drawShadow: widget.drawShadow,
         latestDraggableOffset: _latestDraggableOffset,
         pendingSeekPosition: _pendingSeekPosition,
+        chapters: widget.chapters,
       ),
     );
 
-    return widget.draggableProgressBar
+    final interactive = widget.draggableProgressBar
         ? GestureDetector(
             onHorizontalDragStart: (DragStartDetails details) {
               if (!controller.value.isInitialized) {
@@ -159,6 +165,84 @@ class _VideoProgressBarState extends State<VideoProgressBar> {
             child: MouseRegion(cursor: SystemMouseCursors.click, child: child),
           )
         : child;
+
+    if (widget.chapters.isEmpty) {
+      return interactive;
+    }
+
+    return MouseRegion(
+      onHover: (event) => setState(() => _hoverPosition = event.localPosition),
+      onExit: (_) => setState(() => _hoverPosition = null),
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          return Stack(
+            clipBehavior: Clip.none,
+            children: [interactive, ?_buildChapterLabel(constraints)],
+          );
+        },
+      ),
+    );
+  }
+
+  Widget? _buildChapterLabel(BoxConstraints constraints) {
+    final value = controller.value;
+    if (!value.isInitialized || value.duration <= Duration.zero) {
+      return null;
+    }
+
+    double? pointedDx;
+    if (_latestDraggableOffset != null) {
+      final box = context.findRenderObject() as RenderBox?;
+      if (box != null && box.hasSize) {
+        pointedDx = box.globalToLocal(_latestDraggableOffset!).dx;
+      }
+    } else if (_hoverPosition != null) {
+      pointedDx = _hoverPosition!.dx;
+    }
+    if (pointedDx == null ||
+        !constraints.maxWidth.isFinite ||
+        constraints.maxWidth <= 0) {
+      return null;
+    }
+
+    final clampedDx = pointedDx.clamp(0.0, constraints.maxWidth);
+    final pointedPosition = value.duration * (clampedDx / constraints.maxWidth);
+
+    ChewieChapter? pointedChapter;
+    for (final chapter in widget.chapters) {
+      if (chapter.start > pointedPosition) break;
+      pointedChapter = chapter;
+    }
+    if (pointedChapter == null) {
+      return null;
+    }
+
+    final stackHeight = constraints.maxHeight.isFinite
+        ? constraints.maxHeight
+        : widget.barHeight * 2;
+
+    return Positioned(
+      left: clampedDx,
+      bottom: stackHeight / 2 + widget.barHeight / 2 + widget.handleHeight + 4,
+      child: FractionalTranslation(
+        translation: const Offset(-0.5, 0),
+        child: IgnorePointer(
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+            decoration: BoxDecoration(
+              color: Colors.black.withValues(alpha: 0.8),
+              borderRadius: BorderRadius.circular(4),
+            ),
+            child: Text(
+              '${pointedChapter.title} · ${formatDuration(pointedPosition)}',
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: const TextStyle(color: Colors.white, fontSize: 12),
+            ),
+          ),
+        ),
+      ),
+    );
   }
 }
 
@@ -172,6 +256,7 @@ class StaticProgressBar extends StatelessWidget {
     required this.drawShadow,
     this.latestDraggableOffset,
     this.pendingSeekPosition,
+    this.chapters = const [],
   });
 
   final Offset? latestDraggableOffset;
@@ -186,6 +271,7 @@ class StaticProgressBar extends StatelessWidget {
   final double barHeight;
   final double handleHeight;
   final bool drawShadow;
+  final List<ChewieChapter> chapters;
 
   @override
   Widget build(BuildContext context) {
@@ -206,6 +292,7 @@ class StaticProgressBar extends StatelessWidget {
           barHeight: barHeight,
           handleHeight: handleHeight,
           drawShadow: drawShadow,
+          chapters: chapters,
         ),
       ),
     );
@@ -220,6 +307,7 @@ class _ProgressBarPainter extends CustomPainter {
     required this.handleHeight,
     required this.drawShadow,
     required this.draggableValue,
+    this.chapters = const [],
   });
 
   VideoPlayerValue value;
@@ -228,30 +316,87 @@ class _ProgressBarPainter extends CustomPainter {
   final double barHeight;
   final double handleHeight;
   final bool drawShadow;
+  final List<ChewieChapter> chapters;
 
   /// The position to paint instead of [VideoPlayerValue.position]: either the
   /// one currently being dragged, or the one of a seek that is still in
   /// flight. If null, neither is happening and the reported position is used.
   final Duration? draggableValue;
 
+  static const double _chapterGapWidth = 2.0;
+
   @override
   bool shouldRepaint(CustomPainter painter) {
     return true;
   }
 
+  List<double> _chapterBoundaries(Size size) {
+    final durationMs = value.duration.inMilliseconds;
+    if (durationMs <= 0 || chapters.isEmpty) {
+      return const [];
+    }
+    final boundaries = <double>[];
+    for (final chapter in chapters) {
+      final startMs = chapter.start.inMilliseconds;
+      if (startMs <= 0 || startMs >= durationMs) continue;
+      boundaries.add(startMs / durationMs * size.width);
+    }
+    return boundaries;
+  }
+
+  void _drawBar(
+    Canvas canvas,
+    double fromX,
+    double toX,
+    double baseOffset,
+    Paint paint,
+    List<double> boundaries,
+  ) {
+    if (toX <= fromX) return;
+    var segmentStart = fromX;
+    for (final boundary in boundaries) {
+      if (boundary <= fromX || boundary >= toX) continue;
+      final segmentEnd = boundary - _chapterGapWidth / 2;
+      if (segmentEnd > segmentStart) {
+        canvas.drawRRect(
+          RRect.fromRectAndRadius(
+            Rect.fromPoints(
+              Offset(segmentStart, baseOffset),
+              Offset(segmentEnd, baseOffset + barHeight),
+            ),
+            const Radius.circular(4.0),
+          ),
+          paint,
+        );
+      }
+      segmentStart = boundary + _chapterGapWidth / 2;
+    }
+    if (toX > segmentStart) {
+      canvas.drawRRect(
+        RRect.fromRectAndRadius(
+          Rect.fromPoints(
+            Offset(segmentStart, baseOffset),
+            Offset(toX, baseOffset + barHeight),
+          ),
+          const Radius.circular(4.0),
+        ),
+        paint,
+      );
+    }
+  }
+
   @override
   void paint(Canvas canvas, Size size) {
     final baseOffset = size.height / 2 - barHeight / 2;
+    final boundaries = _chapterBoundaries(size);
 
-    canvas.drawRRect(
-      RRect.fromRectAndRadius(
-        Rect.fromPoints(
-          Offset(0.0, baseOffset),
-          Offset(size.width, baseOffset + barHeight),
-        ),
-        const Radius.circular(4.0),
-      ),
+    _drawBar(
+      canvas,
+      0.0,
+      size.width,
+      baseOffset,
       colors.backgroundPaint,
+      boundaries,
     );
     if (!value.isInitialized) {
       return;
@@ -267,26 +412,22 @@ class _ProgressBarPainter extends CustomPainter {
     for (final DurationRange range in value.buffered) {
       final double start = range.startFraction(value.duration) * size.width;
       final double end = range.endFraction(value.duration) * size.width;
-      canvas.drawRRect(
-        RRect.fromRectAndRadius(
-          Rect.fromPoints(
-            Offset(start, baseOffset),
-            Offset(end, baseOffset + barHeight),
-          ),
-          const Radius.circular(4.0),
-        ),
+      _drawBar(
+        canvas,
+        start,
+        end,
+        baseOffset,
         colors.bufferedPaint,
+        boundaries,
       );
     }
-    canvas.drawRRect(
-      RRect.fromRectAndRadius(
-        Rect.fromPoints(
-          Offset(0.0, baseOffset),
-          Offset(playedPart, baseOffset + barHeight),
-        ),
-        const Radius.circular(4.0),
-      ),
+    _drawBar(
+      canvas,
+      0.0,
+      playedPart,
+      baseOffset,
       colors.playedPaint,
+      boundaries,
     );
 
     if (drawShadow) {

--- a/lib/src/progress_bar.dart
+++ b/lib/src/progress_bar.dart
@@ -128,10 +128,15 @@ class _VideoProgressBarState extends State<VideoProgressBar> {
         : child;
 
     if (widget.chapters.isEmpty) {
-      return interactive;
+      return widget.draggableProgressBar
+          ? MouseRegion(cursor: SystemMouseCursors.click, child: interactive)
+          : interactive;
     }
 
     return MouseRegion(
+      cursor: widget.draggableProgressBar
+          ? SystemMouseCursors.click
+          : MouseCursor.defer,
       onHover: (event) => setState(() => _hoverPosition = event.localPosition),
       onExit: (_) => setState(() => _hoverPosition = null),
       child: LayoutBuilder(

--- a/lib/src/progress_bar.dart
+++ b/lib/src/progress_bar.dart
@@ -1,4 +1,5 @@
 import 'package:chewie/chewie.dart';
+import 'package:chewie/src/helpers/utils.dart';
 import 'package:flutter/material.dart';
 import 'package:video_player/video_player.dart';
 
@@ -14,6 +15,7 @@ class VideoProgressBar extends StatefulWidget {
     required this.barHeight,
     required this.handleHeight,
     required this.drawShadow,
+    this.chapters = const [],
   }) : colors = colors ?? ChewieProgressColors();
 
   final VideoPlayerController controller;
@@ -26,6 +28,7 @@ class VideoProgressBar extends StatefulWidget {
   final double handleHeight;
   final bool drawShadow;
   final bool draggableProgressBar;
+  final List<ChewieChapter> chapters;
 
   @override
   // ignore: library_private_types_in_public_api
@@ -43,6 +46,8 @@ class _VideoProgressBarState extends State<VideoProgressBar> {
   bool _controllerWasPlaying = false;
 
   Offset? _latestDraggableOffset;
+
+  Offset? _hoverPosition;
 
   VideoPlayerController get controller => widget.controller;
 
@@ -74,10 +79,11 @@ class _VideoProgressBarState extends State<VideoProgressBar> {
         handleHeight: widget.handleHeight,
         drawShadow: widget.drawShadow,
         latestDraggableOffset: _latestDraggableOffset,
+        chapters: widget.chapters,
       ),
     );
 
-    return widget.draggableProgressBar
+    final interactive = widget.draggableProgressBar
         ? GestureDetector(
             onHorizontalDragStart: (DragStartDetails details) {
               if (!controller.value.isInitialized) {
@@ -120,6 +126,84 @@ class _VideoProgressBarState extends State<VideoProgressBar> {
             child: MouseRegion(cursor: SystemMouseCursors.click, child: child),
           )
         : child;
+
+    if (widget.chapters.isEmpty) {
+      return interactive;
+    }
+
+    return MouseRegion(
+      onHover: (event) => setState(() => _hoverPosition = event.localPosition),
+      onExit: (_) => setState(() => _hoverPosition = null),
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          return Stack(
+            clipBehavior: Clip.none,
+            children: [interactive, ?_buildChapterLabel(constraints)],
+          );
+        },
+      ),
+    );
+  }
+
+  Widget? _buildChapterLabel(BoxConstraints constraints) {
+    final value = controller.value;
+    if (!value.isInitialized || value.duration <= Duration.zero) {
+      return null;
+    }
+
+    double? pointedDx;
+    if (_latestDraggableOffset != null) {
+      final box = context.findRenderObject() as RenderBox?;
+      if (box != null && box.hasSize) {
+        pointedDx = box.globalToLocal(_latestDraggableOffset!).dx;
+      }
+    } else if (_hoverPosition != null) {
+      pointedDx = _hoverPosition!.dx;
+    }
+    if (pointedDx == null ||
+        !constraints.maxWidth.isFinite ||
+        constraints.maxWidth <= 0) {
+      return null;
+    }
+
+    final clampedDx = pointedDx.clamp(0.0, constraints.maxWidth);
+    final pointedPosition = value.duration * (clampedDx / constraints.maxWidth);
+
+    ChewieChapter? pointedChapter;
+    for (final chapter in widget.chapters) {
+      if (chapter.start > pointedPosition) break;
+      pointedChapter = chapter;
+    }
+    if (pointedChapter == null) {
+      return null;
+    }
+
+    final stackHeight = constraints.maxHeight.isFinite
+        ? constraints.maxHeight
+        : widget.barHeight * 2;
+
+    return Positioned(
+      left: clampedDx,
+      bottom: stackHeight / 2 + widget.barHeight / 2 + widget.handleHeight + 4,
+      child: FractionalTranslation(
+        translation: const Offset(-0.5, 0),
+        child: IgnorePointer(
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+            decoration: BoxDecoration(
+              color: Colors.black.withValues(alpha: 0.8),
+              borderRadius: BorderRadius.circular(4),
+            ),
+            child: Text(
+              '${pointedChapter.title} · ${formatDuration(pointedPosition)}',
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: const TextStyle(color: Colors.white, fontSize: 12),
+            ),
+          ),
+        ),
+      ),
+    );
   }
 }
 
@@ -132,6 +216,7 @@ class StaticProgressBar extends StatelessWidget {
     required this.handleHeight,
     required this.drawShadow,
     this.latestDraggableOffset,
+    this.chapters = const [],
   });
 
   final Offset? latestDraggableOffset;
@@ -141,6 +226,7 @@ class StaticProgressBar extends StatelessWidget {
   final double barHeight;
   final double handleHeight;
   final bool drawShadow;
+  final List<ChewieChapter> chapters;
 
   @override
   Widget build(BuildContext context) {
@@ -161,6 +247,7 @@ class StaticProgressBar extends StatelessWidget {
           barHeight: barHeight,
           handleHeight: handleHeight,
           drawShadow: drawShadow,
+          chapters: chapters,
         ),
       ),
     );
@@ -175,6 +262,7 @@ class _ProgressBarPainter extends CustomPainter {
     required this.handleHeight,
     required this.drawShadow,
     required this.draggableValue,
+    this.chapters = const [],
   });
 
   VideoPlayerValue value;
@@ -183,29 +271,86 @@ class _ProgressBarPainter extends CustomPainter {
   final double barHeight;
   final double handleHeight;
   final bool drawShadow;
+  final List<ChewieChapter> chapters;
 
   /// The value of the draggable progress bar.
   /// If null, the progress bar is not being dragged.
   final Duration? draggableValue;
+
+  static const double _chapterGapWidth = 2.0;
 
   @override
   bool shouldRepaint(CustomPainter painter) {
     return true;
   }
 
+  List<double> _chapterBoundaries(Size size) {
+    final durationMs = value.duration.inMilliseconds;
+    if (durationMs <= 0 || chapters.isEmpty) {
+      return const [];
+    }
+    final boundaries = <double>[];
+    for (final chapter in chapters) {
+      final startMs = chapter.start.inMilliseconds;
+      if (startMs <= 0 || startMs >= durationMs) continue;
+      boundaries.add(startMs / durationMs * size.width);
+    }
+    return boundaries;
+  }
+
+  void _drawBar(
+    Canvas canvas,
+    double fromX,
+    double toX,
+    double baseOffset,
+    Paint paint,
+    List<double> boundaries,
+  ) {
+    if (toX <= fromX) return;
+    var segmentStart = fromX;
+    for (final boundary in boundaries) {
+      if (boundary <= fromX || boundary >= toX) continue;
+      final segmentEnd = boundary - _chapterGapWidth / 2;
+      if (segmentEnd > segmentStart) {
+        canvas.drawRRect(
+          RRect.fromRectAndRadius(
+            Rect.fromPoints(
+              Offset(segmentStart, baseOffset),
+              Offset(segmentEnd, baseOffset + barHeight),
+            ),
+            const Radius.circular(4.0),
+          ),
+          paint,
+        );
+      }
+      segmentStart = boundary + _chapterGapWidth / 2;
+    }
+    if (toX > segmentStart) {
+      canvas.drawRRect(
+        RRect.fromRectAndRadius(
+          Rect.fromPoints(
+            Offset(segmentStart, baseOffset),
+            Offset(toX, baseOffset + barHeight),
+          ),
+          const Radius.circular(4.0),
+        ),
+        paint,
+      );
+    }
+  }
+
   @override
   void paint(Canvas canvas, Size size) {
     final baseOffset = size.height / 2 - barHeight / 2;
+    final boundaries = _chapterBoundaries(size);
 
-    canvas.drawRRect(
-      RRect.fromRectAndRadius(
-        Rect.fromPoints(
-          Offset(0.0, baseOffset),
-          Offset(size.width, baseOffset + barHeight),
-        ),
-        const Radius.circular(4.0),
-      ),
+    _drawBar(
+      canvas,
+      0.0,
+      size.width,
+      baseOffset,
       colors.backgroundPaint,
+      boundaries,
     );
     if (!value.isInitialized) {
       return;
@@ -221,26 +366,22 @@ class _ProgressBarPainter extends CustomPainter {
     for (final DurationRange range in value.buffered) {
       final double start = range.startFraction(value.duration) * size.width;
       final double end = range.endFraction(value.duration) * size.width;
-      canvas.drawRRect(
-        RRect.fromRectAndRadius(
-          Rect.fromPoints(
-            Offset(start, baseOffset),
-            Offset(end, baseOffset + barHeight),
-          ),
-          const Radius.circular(4.0),
-        ),
+      _drawBar(
+        canvas,
+        start,
+        end,
+        baseOffset,
         colors.bufferedPaint,
+        boundaries,
       );
     }
-    canvas.drawRRect(
-      RRect.fromRectAndRadius(
-        Rect.fromPoints(
-          Offset(0.0, baseOffset),
-          Offset(playedPart, baseOffset + barHeight),
-        ),
-        const Radius.circular(4.0),
-      ),
+    _drawBar(
+      canvas,
+      0.0,
+      playedPart,
+      baseOffset,
       colors.playedPaint,
+      boundaries,
     );
 
     if (drawShadow) {

--- a/test/progress_bar_chapters_test.dart
+++ b/test/progress_bar_chapters_test.dart
@@ -49,9 +49,6 @@ class _FakeVideoPlayerController extends VideoPlayerController {
 
   @override
   Future<void> initialize() async {}
-
-  @override
-  Future<void> dispose() async {}
 }
 
 Widget _wrapBar(VideoProgressBar bar) {

--- a/test/progress_bar_chapters_test.dart
+++ b/test/progress_bar_chapters_test.dart
@@ -262,6 +262,19 @@ void main() {
     expect(chapter.start, const Duration(seconds: 5));
   });
 
+  test('ChewieController rejects chapters not sorted by start time', () {
+    expect(
+      () => ChewieController(
+        videoPlayerController: _FakeVideoPlayerController(),
+        chapters: const [
+          ChewieChapter(title: 'Second', start: Duration(minutes: 1)),
+          ChewieChapter(title: 'First', start: Duration.zero),
+        ],
+      ),
+      throwsAssertionError,
+    );
+  });
+
   test('ChewieController exposes chapters and copyWith carries them over', () {
     final controller = ChewieController(
       videoPlayerController: _FakeVideoPlayerController(),

--- a/test/progress_bar_chapters_test.dart
+++ b/test/progress_bar_chapters_test.dart
@@ -1,0 +1,315 @@
+import 'package:chewie/chewie.dart';
+import 'package:chewie/src/progress_bar.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:video_player/video_player.dart';
+
+const _chapters = [
+  ChewieChapter(title: 'Intro', start: Duration.zero),
+  ChewieChapter(title: 'Second Chapter', start: Duration(minutes: 1)),
+  ChewieChapter(title: 'Finale', start: Duration(minutes: 3)),
+];
+
+class _FakeVideoPlayerController extends VideoPlayerController {
+  _FakeVideoPlayerController()
+    : super.networkUrl(Uri.parse('https://example.com/video.m3u8')) {
+    value = VideoPlayerValue(
+      duration: const Duration(minutes: 4),
+      isInitialized: true,
+      position: const Duration(minutes: 2),
+      buffered: [DurationRange(Duration.zero, const Duration(minutes: 3))],
+    );
+  }
+
+  Duration? lastSeek;
+  int playCalls = 0;
+  int pauseCalls = 0;
+
+  @override
+  Future<void> seekTo(Duration position) async {
+    lastSeek = position;
+  }
+
+  @override
+  Future<void> play() async {
+    playCalls++;
+  }
+
+  @override
+  Future<void> pause() async {
+    pauseCalls++;
+  }
+
+  @override
+  Future<void> setLooping(bool looping) async {}
+
+  @override
+  Future<void> setVolume(double volume) async {}
+
+  @override
+  Future<void> initialize() async {}
+
+  @override
+  Future<void> dispose() async {}
+}
+
+Widget _wrapBar(VideoProgressBar bar) {
+  return MaterialApp(
+    home: Scaffold(
+      body: Center(child: SizedBox(width: 400, height: 48, child: bar)),
+    ),
+  );
+}
+
+Future<TestGesture> _hoverAt(WidgetTester tester, Offset location) async {
+  final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+  await gesture.addPointer(location: Offset.zero);
+  addTearDown(gesture.removePointer);
+  await gesture.moveTo(location);
+  await tester.pump();
+  return gesture;
+}
+
+void main() {
+  testWidgets('progress bar with chapters paints segments and handles hover', (
+    tester,
+  ) async {
+    final controller = _FakeVideoPlayerController();
+    await tester.pumpWidget(
+      _wrapBar(
+        VideoProgressBar(
+          controller,
+          barHeight: 10,
+          handleHeight: 6,
+          drawShadow: true,
+          chapters: _chapters,
+        ),
+      ),
+    );
+
+    expect(find.byType(VideoProgressBar), findsOneWidget);
+    expect(tester.takeException(), isNull);
+
+    final barCenter = tester.getCenter(find.byType(VideoProgressBar));
+    final gesture = await _hoverAt(tester, barCenter);
+    await tester.pump();
+
+    expect(find.textContaining('Second Chapter'), findsOneWidget);
+
+    await gesture.moveTo(barCenter - const Offset(150, 0));
+    await tester.pump();
+    expect(find.textContaining('Intro'), findsOneWidget);
+
+    await gesture.moveTo(barCenter + const Offset(180, 0));
+    await tester.pump();
+    expect(find.textContaining('Finale'), findsOneWidget);
+
+    await gesture.moveTo(const Offset(1, 1));
+    await tester.pump();
+    expect(find.textContaining('Finale'), findsNothing);
+  });
+
+  testWidgets('scrubbing shows the pointed chapter and seeks on release', (
+    tester,
+  ) async {
+    final controller = _FakeVideoPlayerController();
+    await tester.pumpWidget(
+      _wrapBar(
+        VideoProgressBar(
+          controller,
+          barHeight: 10,
+          handleHeight: 6,
+          drawShadow: true,
+          chapters: _chapters,
+        ),
+      ),
+    );
+
+    final barCenter = tester.getCenter(find.byType(VideoProgressBar));
+    final drag = await tester.startGesture(barCenter);
+    await drag.moveBy(const Offset(60, 0));
+    await tester.pump();
+    await drag.moveBy(const Offset(60, 0));
+    await tester.pump();
+
+    expect(find.textContaining('Finale'), findsOneWidget);
+
+    await drag.up();
+    await tester.pump();
+
+    expect(controller.lastSeek, isNotNull);
+    expect(controller.lastSeek!, greaterThan(const Duration(minutes: 3)));
+  });
+
+  testWidgets('tap seeks to the tapped position', (tester) async {
+    final controller = _FakeVideoPlayerController();
+    await tester.pumpWidget(
+      _wrapBar(
+        VideoProgressBar(
+          controller,
+          barHeight: 10,
+          handleHeight: 6,
+          drawShadow: true,
+          chapters: _chapters,
+        ),
+      ),
+    );
+
+    await tester.tapAt(tester.getCenter(find.byType(VideoProgressBar)));
+    await tester.pump();
+
+    expect(controller.lastSeek, const Duration(minutes: 2));
+  });
+
+  testWidgets('out-of-range chapter starts are ignored when painting', (
+    tester,
+  ) async {
+    final controller = _FakeVideoPlayerController();
+    await tester.pumpWidget(
+      _wrapBar(
+        VideoProgressBar(
+          controller,
+          barHeight: 10,
+          handleHeight: 6,
+          drawShadow: true,
+          chapters: const [
+            ChewieChapter(title: 'Intro', start: Duration.zero),
+            ChewieChapter(title: 'Beyond', start: Duration(minutes: 10)),
+          ],
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('no chapter label is shown without chapters', (tester) async {
+    final controller = _FakeVideoPlayerController();
+    await tester.pumpWidget(
+      _wrapBar(
+        VideoProgressBar(
+          controller,
+          barHeight: 10,
+          handleHeight: 6,
+          drawShadow: true,
+        ),
+      ),
+    );
+
+    final region = tester.widget<MouseRegion>(
+      find
+          .descendant(
+            of: find.byType(VideoProgressBar),
+            matching: find.byType(MouseRegion),
+          )
+          .first,
+    );
+    expect(region.cursor, SystemMouseCursors.click);
+
+    await _hoverAt(tester, tester.getCenter(find.byType(VideoProgressBar)));
+    await tester.pump();
+    expect(find.byType(Text), findsNothing);
+  });
+
+  testWidgets('non-draggable bar with chapters never seeks', (tester) async {
+    final controller = _FakeVideoPlayerController();
+    await tester.pumpWidget(
+      _wrapBar(
+        VideoProgressBar(
+          controller,
+          barHeight: 10,
+          handleHeight: 6,
+          drawShadow: true,
+          draggableProgressBar: false,
+          chapters: _chapters,
+        ),
+      ),
+    );
+
+    await tester.tapAt(tester.getCenter(find.byType(VideoProgressBar)));
+    await tester.pump();
+
+    expect(controller.lastSeek, isNull);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('uninitialized controller paints the plain background bar', (
+    tester,
+  ) async {
+    final controller = VideoPlayerController.networkUrl(
+      Uri.parse('https://example.com/video.m3u8'),
+    );
+    await tester.pumpWidget(
+      _wrapBar(
+        VideoProgressBar(
+          controller,
+          barHeight: 10,
+          handleHeight: 6,
+          drawShadow: true,
+          chapters: _chapters,
+        ),
+      ),
+    );
+
+    await _hoverAt(tester, tester.getCenter(find.byType(VideoProgressBar)));
+    await tester.pump();
+
+    expect(find.byType(Text), findsNothing);
+    expect(tester.takeException(), isNull);
+  });
+
+  test('ChewieChapter holds its title and start time', () {
+    const chapter = ChewieChapter(title: 'Intro', start: Duration(seconds: 5));
+    expect(chapter.title, 'Intro');
+    expect(chapter.start, const Duration(seconds: 5));
+  });
+
+  test('ChewieController exposes chapters and copyWith carries them over', () {
+    final controller = ChewieController(
+      videoPlayerController: _FakeVideoPlayerController(),
+      chapters: _chapters,
+    );
+    expect(controller.chapters, _chapters);
+
+    final unchanged = controller.copyWith();
+    expect(unchanged.chapters, _chapters);
+
+    const replacement = [ChewieChapter(title: 'Only', start: Duration.zero)];
+    final replaced = controller.copyWith(chapters: replacement);
+    expect(replaced.chapters, replacement);
+  });
+
+  for (final (String name, Widget controls) in [
+    ('MaterialControls', const MaterialControls()),
+    ('MaterialDesktopControls', const MaterialDesktopControls()),
+    (
+      'CupertinoControls',
+      const CupertinoControls(
+        backgroundColor: Colors.black,
+        iconColor: Colors.white,
+      ),
+    ),
+  ]) {
+    testWidgets('$name forwards chapters to its progress bar', (tester) async {
+      final chewieController = ChewieController(
+        videoPlayerController: _FakeVideoPlayerController(),
+        chapters: _chapters,
+        customControls: controls,
+      );
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: Chewie(controller: chewieController)),
+        ),
+      );
+      await tester.pump();
+
+      final bar = tester.widget<VideoProgressBar>(
+        find.byType(VideoProgressBar),
+      );
+      expect(bar.chapters, _chapters);
+
+      await tester.pumpWidget(const SizedBox());
+    });
+  }
+}


### PR DESCRIPTION
### Description

Adds an optional `chapters` list to `ChewieController` (`ChewieChapter { title, start }`). When provided, the progress bar is drawn split into chapter segments with a small 2px gap at each chapter boundary — the YouTube-style chaptered timeline — and hovering or scrubbing the bar shows a floating pill with the pointed chapter's title next to the timecode.

All three control skins (Material, MaterialDesktop, Cupertino) get the segmented rendering, since they all funnel into the shared `VideoProgressBar`/`_ProgressBarPainter`.

### Behaviour

- `chapters` defaults to an empty list: the painter and widget tree are exactly as before, so existing apps are unaffected.
- The list must be sorted by ascending start time; a debug-mode assert in `ChewieController` enforces it.
- Background, buffered, and played bars are all segmented consistently; boundaries outside `(0, duration)` are ignored defensively.
- The title pill is driven by hover events (desktop) and by an in-progress drag, so plain touch playback is unchanged.
- Purely additive; no breaking API changes.

### Notes

The branch is up to date with `master`, on top of the click-cursor change from #950. The hover pill here shares its look with the hover-time indicator proposed in #956 — if both land, they compose naturally (title + timecode in one label).
