### PR TITLE
feat: Expose showPlayButton on ChewieController

### DIFF
--- a/lib/src/chewie_player.dart
+++ b/lib/src/chewie_player.dart
@@ -337,6 +337,7 @@ class ChewieController extends ChangeNotifier {
     this.optionsBuilder,
     this.additionalOptions,
     this.showControls = true,
+    this.showPlayButton = true,
     this.transformationController,
     this.zoomAndPan = false,
     this.maxScale = 2.5,
@@ -392,6 +393,7 @@ class ChewieController extends ChangeNotifier {
     Future<void> Function(BuildContext, List<OptionItem>)? optionsBuilder,
     List<OptionItem> Function(BuildContext)? additionalOptions,
     bool? showControls,
+    bool? showPlayButton,
     TransformationController? transformationController,
     bool? zoomAndPan,
     double? maxScale,
@@ -459,6 +461,7 @@ class ChewieController extends ChangeNotifier {
       optionsBuilder: optionsBuilder ?? this.optionsBuilder,
       additionalOptions: additionalOptions ?? this.additionalOptions,
       showControls: showControls ?? this.showControls,
+      showPlayButton: showPlayButton ?? this.showPlayButton,
       showSubtitles: showSubtitles ?? this.showSubtitles,
       subtitle: subtitle ?? this.subtitle,
       subtitleBuilder: subtitleBuilder ?? this.subtitleBuilder,
@@ -572,6 +575,10 @@ class ChewieController extends ChangeNotifier {
 
   /// Whether or not to show the controls at all
   final bool showControls;
+
+  /// Whether or not to show the center play button.
+  /// Only used when [customControls] is not set.
+  final bool showPlayButton;
 
   /// Controller to pass into the [InteractiveViewer] component.
   /// If it is required to control the transformation only via the controller,

--- a/lib/src/helpers/adaptive_controls.dart
+++ b/lib/src/helpers/adaptive_controls.dart
@@ -2,24 +2,27 @@ import 'package:chewie/chewie.dart';
 import 'package:flutter/material.dart';
 
 class AdaptiveControls extends StatelessWidget {
-  const AdaptiveControls({super.key});
+  const AdaptiveControls({this.showPlayButton = true, super.key});
+
+  final bool showPlayButton;
 
   @override
   Widget build(BuildContext context) {
     switch (Theme.of(context).platform) {
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:
-        return const MaterialControls();
+        return MaterialControls(showPlayButton: showPlayButton);
 
       case TargetPlatform.macOS:
       case TargetPlatform.windows:
       case TargetPlatform.linux:
-        return const MaterialDesktopControls();
+        return MaterialDesktopControls(showPlayButton: showPlayButton);
 
       case TargetPlatform.iOS:
-        return const CupertinoControls(
-          backgroundColor: Color.fromRGBO(41, 41, 41, 0.7),
-          iconColor: Color.fromARGB(255, 200, 200, 200),
+        return CupertinoControls(
+          backgroundColor: const Color.fromRGBO(41, 41, 41, 0.7),
+          iconColor: const Color.fromARGB(255, 200, 200, 200),
+          showPlayButton: showPlayButton,
         );
     }
   }

--- a/lib/src/player_with_controls.dart
+++ b/lib/src/player_with_controls.dart
@@ -25,7 +25,10 @@ class PlayerWithControls extends StatelessWidget {
       ChewieController chewieController,
     ) {
       return chewieController.showControls
-          ? chewieController.customControls ?? const AdaptiveControls()
+          ? chewieController.customControls ??
+                AdaptiveControls(
+                  showPlayButton: chewieController.showPlayButton,
+                )
           : const SizedBox();
     }
 


### PR DESCRIPTION
## Summary

Closes #494

Adds a `showPlayButton` parameter to `ChewieController` so users can hide the large center play button without providing fully custom controls.

### Before
```dart
// Had to create custom controls just to hide the play button
ChewieController(
  customControls: const MaterialControls(showPlayButton: false),
  // ...
);
```

### After
```dart
ChewieController(
  showPlayButton: false,
  // ...
);
```

## Changes

- **`chewie_player.dart`**: Added `showPlayButton` field (defaults to `true`) to `ChewieController` constructor, `copyWith`, and field declarations
- **`adaptive_controls.dart`**: `AdaptiveControls` now accepts and forwards `showPlayButton` to `MaterialControls`, `MaterialDesktopControls`, and `CupertinoControls`
- **`player_with_controls.dart`**: Passes `chewieController.showPlayButton` to `AdaptiveControls` when no `customControls` is set

## Test plan

- [x] All 83 existing tests pass
- [x] `flutter analyze` reports no issues
- [x] `dart format` reports no changes needed
- [x] Backward compatible — defaults to `true` (existing behavior unchanged)