### PR TITLE
Add ChewieController.swapVideoSource (in-place video source replacement)

### DIFF
--- a/lib/src/chewie_player.dart
+++ b/lib/src/chewie_player.dart
@@ -78,6 +78,7 @@ class ChewieState extends State<Chewie> {
   @override
   void didUpdateWidget(Chewie oldWidget) {
     if (oldWidget.controller != widget.controller) {
+      oldWidget.controller.removeListener(listener);
       widget.controller.addListener(listener);
     }
     super.didUpdateWidget(oldWidget);
@@ -93,7 +94,7 @@ class ChewieState extends State<Chewie> {
       _resumeAppliedInFullScreen = false;
       _isFullScreen = isControllerFullScreen;
       await _pushFullScreenWidget(context);
-    } else if (_isFullScreen) {
+    } else if (!isControllerFullScreen && _isFullScreen) {
       Navigator.of(
         context,
         rootNavigator: widget.controller.useRootNavigator,
@@ -317,7 +318,7 @@ class ChewieState extends State<Chewie> {
 /// `VideoPlayerController`.
 class ChewieController extends ChangeNotifier {
   ChewieController({
-    required this.videoPlayerController,
+    required VideoPlayerController videoPlayerController,
     this.optionsTranslation,
     this.aspectRatio,
     this.autoInitialize = false,
@@ -364,7 +365,8 @@ class ChewieController extends ChangeNotifier {
     this.hideControlsTimer = defaultHideControlsTimer,
     this.controlsSafeAreaMinimum = EdgeInsets.zero,
     this.pauseOnBackgroundTap = false,
-  }) : assert(
+  }) : _videoPlayerController = videoPlayerController,
+       assert(
          playbackSpeeds.every((speed) => speed > 0),
          'The playbackSpeeds values must all be greater than 0',
        ) {
@@ -549,8 +551,12 @@ class ChewieController extends ChangeNotifier {
   /// begins playing. If set to `false`, subtitles will be hidden by default.
   bool showSubtitles;
 
-  /// The controller for the video you want to play
-  final VideoPlayerController videoPlayerController;
+  /// The controller for the video you want to play.
+  ///
+  /// Replaced by [swapVideoSource]; hosts that swap sources should read this
+  /// getter (rather than keep their own reference) when disposing.
+  VideoPlayerController get videoPlayerController => _videoPlayerController;
+  VideoPlayerController _videoPlayerController;
 
   /// Initialize the Video on Startup. This will prep the video for playback.
   final bool autoInitialize;
@@ -727,6 +733,56 @@ class ChewieController extends ChangeNotifier {
     if (videoPlayerController.value.isPlaying && !_isFullScreen) {
       enterFullScreen();
       videoPlayerController.removeListener(_fullScreenListener);
+    }
+  }
+
+  /// Replaces [videoPlayerController] with [newController], preserving the
+  /// playback position, speed, volume, looping and play/pause state of the
+  /// old controller.
+  ///
+  /// Use this to switch to another rendition of the current video (e.g. a
+  /// different quality) without rebuilding the [ChewieController].
+  ///
+  /// [newController] is initialized before the swap, so the player never
+  /// shows an unready source; if initialization fails, the error is rethrown
+  /// and the old controller stays in place. Chewie takes ownership of
+  /// [newController]: the old controller is disposed after the UI has
+  /// re-attached, and the host's own dispose should read
+  /// [videoPlayerController] rather than keep a reference to a controller
+  /// created earlier. Pass [disposeOldController] as `false` to keep the old
+  /// controller alive instead — for example when swapping between preloaded
+  /// controllers the host still owns.
+  Future<void> swapVideoSource(
+    VideoPlayerController newController, {
+    bool disposeOldController = true,
+  }) async {
+    final oldController = _videoPlayerController;
+    final oldValue = oldController.value;
+
+    if (!newController.value.isInitialized) {
+      await newController.initialize();
+    }
+    await newController.setLooping(looping);
+    if (oldValue.isInitialized && oldValue.position > Duration.zero) {
+      await newController.seekTo(oldValue.position);
+    }
+    await newController.setPlaybackSpeed(oldValue.playbackSpeed);
+    await newController.setVolume(oldValue.volume);
+    if (oldValue.isPlaying) {
+      await newController.play();
+    }
+
+    // No-op unless fullScreenByDefault attached it and it hasn't fired yet.
+    oldController.removeListener(_fullScreenListener);
+    _videoPlayerController = newController;
+    notifyListeners();
+
+    if (disposeOldController) {
+      // Wait for the frame triggered by notifyListeners(), so the rebuilt
+      // controls have detached their listeners from the old controller.
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        oldController.dispose();
+      });
     }
   }
 

--- a/lib/src/player_with_controls.dart
+++ b/lib/src/player_with_controls.dart
@@ -25,7 +25,13 @@ class PlayerWithControls extends StatelessWidget {
       ChewieController chewieController,
     ) {
       return chewieController.showControls
-          ? chewieController.customControls ?? const AdaptiveControls()
+          // Keyed on the video controller so the controls are recreated (and
+          // re-attach their listeners) when swapVideoSource replaces it.
+          ? KeyedSubtree(
+              key: ObjectKey(chewieController.videoPlayerController),
+              child:
+                  chewieController.customControls ?? const AdaptiveControls(),
+            )
           : const SizedBox();
     }
 
@@ -96,17 +102,25 @@ class PlayerWithControls extends StatelessWidget {
       return child;
     }
 
-    return LayoutBuilder(
-      builder: (BuildContext context, BoxConstraints constraints) {
-        return Center(
-          child: SizedBox(
-            height: constraints.maxHeight,
-            width: constraints.maxWidth,
-            child: AspectRatio(
-              aspectRatio: calculateAspectRatio(context),
-              child: buildPlayerWithControls(chewieController, context),
-            ),
-          ),
+    // The provider only notifies dependents when the controller instance
+    // changes, so listen to the controller itself to rebuild on mutations
+    // such as swapVideoSource.
+    return ListenableBuilder(
+      listenable: chewieController,
+      builder: (BuildContext context, Widget? _) {
+        return LayoutBuilder(
+          builder: (BuildContext context, BoxConstraints constraints) {
+            return Center(
+              child: SizedBox(
+                height: constraints.maxHeight,
+                width: constraints.maxWidth,
+                child: AspectRatio(
+                  aspectRatio: calculateAspectRatio(context),
+                  child: buildPlayerWithControls(chewieController, context),
+                ),
+              ),
+            );
+          },
         );
       },
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,9 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^6.0.0
+  # Only used by the fake platform the tests install, so controllers can
+  # actually initialize under `flutter test`.
+  video_player_platform_interface: ^6.9.0
 
 flutter:
   uses-material-design: true

--- a/test/fake_video_player_platform.dart
+++ b/test/fake_video_player_platform.dart
@@ -1,0 +1,150 @@
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+import 'package:video_player_platform_interface/video_player_platform_interface.dart';
+
+/// A minimal in-memory [VideoPlayerPlatform] so tests can drive controllers
+/// whose `initialize()` actually completes.
+///
+/// Without one, `VideoPlayerController.initialize()` never finishes under
+/// `flutter test`, and anything that waits on it — such as
+/// `ChewieController.swapVideoSource` — stalls forever.
+class FakeVideoPlayerPlatform extends VideoPlayerPlatform {
+  FakeVideoPlayerPlatform({this.duration = const Duration(minutes: 5)});
+
+  /// Duration reported for every player created.
+  final Duration duration;
+
+  /// Sources containing this marker make [createWithOptions] throw, so tests
+  /// can exercise initialization failures.
+  static const String failingSource = 'fake-init-failure';
+
+  final Map<int, StreamController<VideoEvent>> _events = {};
+  final Map<int, Duration> _positions = {};
+  final Map<int, bool> _playing = {};
+  final Map<int, bool> _looping = {};
+  final Map<int, double> _speeds = {};
+  final Map<int, double> _volumes = {};
+
+  /// Player ids that have been disposed, in dispose order.
+  final List<int> disposedPlayerIds = [];
+
+  /// Player id created for each data-source URI, most recent wins.
+  final Map<String, int> playerIdsBySource = {};
+
+  int _nextPlayerId = 1;
+
+  /// Installs a fresh fake platform for the current test and returns it.
+  static FakeVideoPlayerPlatform install() {
+    final platform = FakeVideoPlayerPlatform();
+    VideoPlayerPlatform.instance = platform;
+    return platform;
+  }
+
+  int playerIdFor(String source) => playerIdsBySource[source]!;
+  bool isPlaying(int playerId) => _playing[playerId] ?? false;
+  bool isLooping(int playerId) => _looping[playerId] ?? false;
+  double speedOf(int playerId) => _speeds[playerId] ?? 1.0;
+  double volumeOf(int playerId) => _volumes[playerId] ?? 1.0;
+  Duration positionOf(int playerId) => _positions[playerId] ?? Duration.zero;
+
+  @override
+  Future<void> init() async {}
+
+  @override
+  Future<int?> createWithOptions(VideoCreationOptions options) async {
+    final source =
+        options.dataSource.uri ?? options.dataSource.asset ?? 'unknown';
+    if (source.contains(failingSource)) {
+      throw StateError('FakeVideoPlayerPlatform refused source: $source');
+    }
+    final playerId = _nextPlayerId++;
+    // Closed in dispose(), which the lint cannot see from here.
+    // ignore: close_sinks
+    _events[playerId] = StreamController<VideoEvent>.broadcast();
+    _positions[playerId] = Duration.zero;
+    playerIdsBySource[source] = playerId;
+    return playerId;
+  }
+
+  @override
+  Future<void> dispose(int playerId) async {
+    disposedPlayerIds.add(playerId);
+    await _events.remove(playerId)?.close();
+  }
+
+  @override
+  Stream<VideoEvent> videoEventsFor(int playerId) {
+    // A plain broadcast stream, not an async* generator: cancelling a
+    // generator's subscription never completes under the test framework's
+    // fake async, which would stall VideoPlayerController.dispose().
+    // The initialized event goes out in a microtask so the controller —
+    // which listens synchronously after this call — is subscribed by then.
+    scheduleMicrotask(() {
+      _events[playerId]?.add(
+        VideoEvent(
+          eventType: VideoEventType.initialized,
+          duration: duration,
+          size: const Size(1920, 1080),
+        ),
+      );
+    });
+    return _events[playerId]!.stream;
+  }
+
+  @override
+  Future<void> setLooping(int playerId, bool looping) async {
+    _looping[playerId] = looping;
+  }
+
+  @override
+  Future<void> play(int playerId) async {
+    _playing[playerId] = true;
+  }
+
+  @override
+  Future<void> pause(int playerId) async {
+    _playing[playerId] = false;
+  }
+
+  @override
+  Future<void> setVolume(int playerId, double volume) async {
+    _volumes[playerId] = volume;
+  }
+
+  @override
+  Future<void> setPlaybackSpeed(int playerId, double speed) async {
+    _speeds[playerId] = speed;
+  }
+
+  @override
+  Future<void> seekTo(int playerId, Duration position) async {
+    _positions[playerId] = position;
+  }
+
+  @override
+  Future<Duration> getPosition(int playerId) async =>
+      _positions[playerId] ?? Duration.zero;
+
+  @override
+  Future<void> setMixWithOthers(bool mixWithOthers) async {}
+
+  @override
+  Future<void> setWebOptions(
+    int playerId,
+    VideoPlayerWebOptions options,
+  ) async {}
+
+  @override
+  Future<void> setPreventsDisplaySleepDuringVideoPlayback(
+    int playerId,
+    bool preventsDisplaySleep,
+  ) async {}
+
+  @override
+  Widget buildView(int playerId) => const SizedBox.expand();
+
+  @override
+  Widget buildViewWithOptions(VideoViewOptions options) =>
+      const SizedBox.expand();
+}

--- a/test/swap_video_source_test.dart
+++ b/test/swap_video_source_test.dart
@@ -1,0 +1,236 @@
+import 'dart:async';
+
+import 'package:chewie/chewie.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:video_player/video_player.dart';
+
+import 'fake_video_player_platform.dart';
+
+const String _srcA = 'https://example.com/video-a.mp4';
+const String _srcB = 'https://example.com/video-b.mp4';
+const String _srcBad =
+    'https://example.com/${FakeVideoPlayerPlatform.failingSource}.mp4';
+
+VideoPlayerController _network(String src) =>
+    VideoPlayerController.networkUrl(Uri.parse(src));
+
+/// Drives one frame outside of pumpWidget, so post-frame callbacks — like the
+/// deferred disposal in [ChewieController.swapVideoSource] — get to run.
+Future<void> _driveFrame() async {
+  final binding = TestWidgetsFlutterBinding.instance;
+  binding.handleBeginFrame(Duration.zero);
+  binding.handleDrawFrame();
+  await Future<void>.delayed(Duration.zero);
+}
+
+class _PopCountingObserver extends NavigatorObserver {
+  int pops = 0;
+
+  @override
+  void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    pops++;
+    super.didPop(route, previousRoute);
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late FakeVideoPlayerPlatform platform;
+
+  setUp(() {
+    platform = FakeVideoPlayerPlatform.install();
+  });
+
+  // Controller-level tests use test(), not testWidgets(): under fake async,
+  // VideoPlayerController.dispose() stalls on its event-subscription cleanup
+  // and can never be awaited to completion.
+  group('ChewieController.swapVideoSource', () {
+    test(
+      'initializes the new controller and preserves playback state',
+      () async {
+        final oldVpc = _network(_srcA);
+        await oldVpc.initialize();
+        final chewieController = ChewieController(
+          videoPlayerController: oldVpc,
+          looping: true,
+        );
+        await oldVpc.seekTo(const Duration(seconds: 42));
+        await oldVpc.setPlaybackSpeed(1.5);
+        await oldVpc.setVolume(0.5);
+        await oldVpc.play();
+
+        final newVpc = _network(_srcB);
+        await chewieController.swapVideoSource(newVpc);
+
+        expect(chewieController.videoPlayerController, same(newVpc));
+        expect(newVpc.value.isInitialized, isTrue);
+        expect(newVpc.value.position, const Duration(seconds: 42));
+        expect(newVpc.value.playbackSpeed, 1.5);
+        expect(newVpc.value.volume, 0.5);
+        expect(newVpc.value.isPlaying, isTrue);
+        expect(platform.isLooping(platform.playerIdFor(_srcB)), isTrue);
+
+        await _driveFrame();
+        await newVpc.dispose();
+        chewieController.dispose();
+      },
+    );
+
+    test('notifies listeners exactly once', () async {
+      final oldVpc = _network(_srcA);
+      await oldVpc.initialize();
+      final chewieController = ChewieController(videoPlayerController: oldVpc);
+      var notified = 0;
+      chewieController.addListener(() => notified++);
+
+      final newVpc = _network(_srcB);
+      await chewieController.swapVideoSource(newVpc);
+
+      expect(notified, 1);
+
+      await _driveFrame();
+      await newVpc.dispose();
+      chewieController.dispose();
+    });
+
+    test('disposes the old controller after the next frame', () async {
+      final oldVpc = _network(_srcA);
+      await oldVpc.initialize();
+      final oldPlayerId = platform.playerIdFor(_srcA);
+      final chewieController = ChewieController(videoPlayerController: oldVpc);
+
+      final newVpc = _network(_srcB);
+      await chewieController.swapVideoSource(newVpc);
+      expect(platform.disposedPlayerIds, isEmpty);
+
+      await _driveFrame();
+      expect(platform.disposedPlayerIds, [oldPlayerId]);
+
+      await newVpc.dispose();
+      chewieController.dispose();
+    });
+
+    test('keeps the old controller with disposeOldController: false', () async {
+      final oldVpc = _network(_srcA);
+      await oldVpc.initialize();
+      final chewieController = ChewieController(videoPlayerController: oldVpc);
+
+      final newVpc = _network(_srcB);
+      await chewieController.swapVideoSource(
+        newVpc,
+        disposeOldController: false,
+      );
+      await _driveFrame();
+
+      expect(platform.disposedPlayerIds, isEmpty);
+
+      await oldVpc.dispose();
+      await newVpc.dispose();
+      chewieController.dispose();
+    });
+
+    test(
+      'rethrows on initialization failure and keeps the old source',
+      () async {
+        final oldVpc = _network(_srcA);
+        await oldVpc.initialize();
+        final chewieController = ChewieController(
+          videoPlayerController: oldVpc,
+        );
+        var notified = 0;
+        chewieController.addListener(() => notified++);
+
+        // Not disposed at the end: a controller whose platform create() threw
+        // cannot complete dispose(), and it holds no timers or platform state.
+        final badVpc = _network(_srcBad);
+        await expectLater(
+          chewieController.swapVideoSource(badVpc),
+          throwsStateError,
+        );
+
+        expect(chewieController.videoPlayerController, same(oldVpc));
+        expect(notified, 0);
+        await _driveFrame();
+        expect(platform.disposedPlayerIds, isEmpty);
+
+        await oldVpc.dispose();
+        chewieController.dispose();
+      },
+    );
+  });
+
+  // Widget tests run under fake async, where awaiting
+  // VideoPlayerController.dispose() never completes — cleanup disposals are
+  // fire-and-forget there (they still cancel their timers).
+  group('swapVideoSource widget integration', () {
+    testWidgets('re-attaches the video widget and controls after a swap', (
+      tester,
+    ) async {
+      final oldVpc = _network(_srcA);
+      await oldVpc.initialize();
+      final chewieController = ChewieController(videoPlayerController: oldVpc);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: Chewie(controller: chewieController)),
+        ),
+      );
+      expect(
+        tester.widget<VideoPlayer>(find.byType(VideoPlayer)).controller,
+        same(oldVpc),
+      );
+
+      final newVpc = _network(_srcB);
+      await chewieController.swapVideoSource(newVpc);
+      await tester.pump();
+      await tester.pump();
+
+      expect(
+        tester.widget<VideoPlayer>(find.byType(VideoPlayer)).controller,
+        same(newVpc),
+      );
+      expect(tester.takeException(), isNull);
+
+      await tester.pumpWidget(const SizedBox());
+      unawaited(newVpc.dispose());
+      await tester.pump();
+      chewieController.dispose();
+    });
+
+    testWidgets('does not pop the fullscreen route (#618)', (tester) async {
+      final oldVpc = _network(_srcA);
+      await oldVpc.initialize();
+      final chewieController = ChewieController(videoPlayerController: oldVpc);
+      final observer = _PopCountingObserver();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          navigatorObservers: [observer],
+          home: Scaffold(body: Chewie(controller: chewieController)),
+        ),
+      );
+
+      chewieController.enterFullScreen();
+      await tester.pumpAndSettle();
+      expect(chewieController.isFullScreen, isTrue);
+
+      final newVpc = _network(_srcB);
+      await chewieController.swapVideoSource(newVpc);
+      await tester.pumpAndSettle();
+
+      expect(chewieController.isFullScreen, isTrue);
+      expect(observer.pops, 0);
+
+      chewieController.exitFullScreen();
+      await tester.pumpAndSettle();
+      expect(observer.pops, 1);
+
+      await tester.pumpWidget(const SizedBox());
+      unawaited(newVpc.dispose());
+      await tester.pump();
+      chewieController.dispose();
+    });
+  });
+}

--- a/test/swap_video_source_test.dart
+++ b/test/swap_video_source_test.dart
@@ -26,11 +26,18 @@ Future<void> _driveFrame() async {
 
 class _PopCountingObserver extends NavigatorObserver {
   int pops = 0;
+  int pushes = 0;
 
   @override
   void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) {
     pops++;
     super.didPop(route, previousRoute);
+  }
+
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    pushes++;
+    super.didPush(route, previousRoute);
   }
 }
 
@@ -232,5 +239,47 @@ void main() {
       await tester.pump();
       chewieController.dispose();
     });
+
+    testWidgets(
+      're-targets its listener when rebuilt with a different controller',
+      (tester) async {
+        final vpcA = _network(_srcA);
+        await vpcA.initialize();
+        final vpcB = _network(_srcB);
+        await vpcB.initialize();
+        final controllerA = ChewieController(videoPlayerController: vpcA);
+        final controllerB = ChewieController(videoPlayerController: vpcB);
+        final observer = _PopCountingObserver();
+
+        Widget app(ChewieController controller) => MaterialApp(
+          navigatorObservers: [observer],
+          home: Scaffold(body: Chewie(controller: controller)),
+        );
+
+        await tester.pumpWidget(app(controllerA));
+        await tester.pumpWidget(app(controllerB));
+        final pushesAfterMount = observer.pushes;
+
+        // The old controller no longer drives this Chewie.
+        controllerA.enterFullScreen();
+        await tester.pumpAndSettle();
+        expect(observer.pushes, pushesAfterMount);
+
+        // The new one does.
+        controllerB.enterFullScreen();
+        await tester.pumpAndSettle();
+        expect(observer.pushes, pushesAfterMount + 1);
+
+        controllerB.exitFullScreen();
+        await tester.pumpAndSettle();
+
+        await tester.pumpWidget(const SizedBox());
+        unawaited(vpcA.dispose());
+        unawaited(vpcB.dispose());
+        await tester.pump();
+        controllerA.dispose();
+        controllerB.dispose();
+      },
+    );
   });
 }


### PR DESCRIPTION
## What this adds

`ChewieController.swapVideoSource(VideoPlayerController newController, {bool disposeOldController = true})` — replaces the internal `VideoPlayerController` in place while preserving **position, playback speed, volume, looping and play/pause state**. The new controller is initialized *before* the swap (the player never shows an unready source; on failure the error is rethrown and the old controller stays), and the old controller is disposed *after* the UI has re-attached. `disposeOldController: false` opts out, for hosts that pool preloaded controllers.

To make an in-place swap actually reach the screen, `PlayerWithControls` now listens to the `ChewieController` (the `InheritedWidget` only notifies on controller *identity* changes) and keys the controls subtree on the video controller, so the control skins are recreated and re-attach their listeners to the new controller. `VideoPlayer` itself re-attaches through its own `didUpdateWidget`.

## Bugs fixed on the way

- **#618** — `ChewieState.listener()` popped the current route on *any* `notifyListeners()` while fullscreen (`else if (_isFullScreen)`), not just on an actual exit-fullscreen request. Since `swapVideoSource` notifies, this fix is a prerequisite; it also fixes the original speed-dialog report.
- `Chewie.didUpdateWidget` re-added its listener to the new controller without removing it from the old one (listener leak).

## Why

This is groundwork for quality switching (see the follow-up PR). #492 and #867 both needed to replace the controller in place and both struggled with the same three problems this PR isolates and tests: preserving playback state, getting the UI to re-attach, and disposing the old controller safely — the missing dispose is the crash documented in #779. Thanks @merdweebner (#492) and @akmalova (#867) for the groundwork.

## Tests

New `FakeVideoPlayerPlatform` (dev-dep on `video_player_platform_interface` only) so controllers can actually initialize under `flutter test`, plus 7 tests covering: state preservation, single notification, deferred disposal of the old controller, the `disposeOldController: false` opt-out, initialization-failure rollback, video/controls re-attachment, and a #618 regression test (swap while fullscreen keeps the route).
