### PR TITLE
Fix progress bar handle snapping back during a seek

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [Unreleased]
+* 🛠️ Fix the progress bar handle snapping back to the previous position for the duration of a seek (most visible on iOS, where an exact seek is slow to complete). The requested position is now painted until the controller reports it, and playback resumes only once the seek has landed.
+
 ## [1.15.0]
 * 🌐 [#946](https://github.com/fluttercommunity/chewie/pull/946): Web: enter the browser's native (OS-level) fullscreen via the Fullscreen API instead of only expanding the Flutter view inside the browser window. Pressing Escape to leave browser fullscreen also exits Chewie's fullscreen. Controlled by the new `ChewieController.useNativeFullScreenOnWeb` flag (defaults to `true`; no effect on non-web platforms). Thanks [Ortes](https://github.com/Ortes).
 * 🖱️ [#950](https://github.com/fluttercommunity/chewie/pull/950): Show click cursor on hover over Material controls and progress bar. Thanks [Ortes](https://github.com/Ortes).

--- a/lib/src/progress_bar.dart
+++ b/lib/src/progress_bar.dart
@@ -44,6 +44,22 @@ class _VideoProgressBarState extends State<VideoProgressBar> {
 
   Offset? _latestDraggableOffset;
 
+  /// The position the controller has been asked to seek to, kept around until
+  /// the seek actually completes.
+  ///
+  /// [VideoPlayerController.seekTo] only updates
+  /// [VideoPlayerValue.position] once the platform is done seeking, which can
+  /// take a noticeable amount of time (especially on iOS, where an exact seek
+  /// has to wait for `AVPlayer` to decode the target frame). Painting the
+  /// requested position in the meantime keeps the handle where the user
+  /// dropped it instead of letting it snap back to the stale position for a
+  /// few frames.
+  Duration? _pendingSeekPosition;
+
+  /// Identifies the latest seek request so a stale one cannot clear the
+  /// position requested by a newer one.
+  int _latestSeekRequestId = 0;
+
   VideoPlayerController get controller => widget.controller;
 
   @override
@@ -58,10 +74,30 @@ class _VideoProgressBarState extends State<VideoProgressBar> {
     super.deactivate();
   }
 
-  void _seekToRelativePosition(Offset globalPosition) {
-    controller.seekTo(
+  Future<void> _seekToRelativePosition(Offset globalPosition) {
+    return _seekTo(
       context.calcRelativePosition(controller.value.duration, globalPosition),
     );
+  }
+
+  Future<void> _seekTo(Duration position) async {
+    final int requestId = ++_latestSeekRequestId;
+
+    setState(() {
+      _pendingSeekPosition = position;
+      _latestDraggableOffset = null;
+    });
+
+    try {
+      await controller.seekTo(position);
+    } finally {
+      // A newer seek is already driving the handle, leave it alone.
+      if (mounted && requestId == _latestSeekRequestId) {
+        setState(() {
+          _pendingSeekPosition = null;
+        });
+      }
+    }
   }
 
   @override
@@ -74,6 +110,7 @@ class _VideoProgressBarState extends State<VideoProgressBar> {
         handleHeight: widget.handleHeight,
         drawShadow: widget.drawShadow,
         latestDraggableOffset: _latestDraggableOffset,
+        pendingSeekPosition: _pendingSeekPosition,
       ),
     );
 
@@ -99,17 +136,19 @@ class _VideoProgressBarState extends State<VideoProgressBar> {
 
               widget.onDragUpdate?.call();
             },
-            onHorizontalDragEnd: (DragEndDetails details) {
+            onHorizontalDragEnd: (DragEndDetails details) async {
+              widget.onDragEnd?.call();
+
+              final Offset? dragOffset = _latestDraggableOffset;
+              if (dragOffset != null) {
+                // Resume playback only once the seek landed, otherwise the
+                // player briefly plays from the position it was left at.
+                await _seekToRelativePosition(dragOffset);
+              }
+
               if (_controllerWasPlaying) {
                 controller.play();
               }
-
-              if (_latestDraggableOffset != null) {
-                _seekToRelativePosition(_latestDraggableOffset!);
-                _latestDraggableOffset = null;
-              }
-
-              widget.onDragEnd?.call();
             },
             onTapDown: (TapDownDetails details) {
               if (!controller.value.isInitialized) {
@@ -132,9 +171,15 @@ class StaticProgressBar extends StatelessWidget {
     required this.handleHeight,
     required this.drawShadow,
     this.latestDraggableOffset,
+    this.pendingSeekPosition,
   });
 
   final Offset? latestDraggableOffset;
+
+  /// Position of a seek that has been requested but has not been reported by
+  /// the controller yet. Painted while it is set, so the handle does not fall
+  /// back to the stale [VideoPlayerValue.position] mid-seek.
+  final Duration? pendingSeekPosition;
   final VideoPlayerValue value;
   final ChewieProgressColors colors;
 
@@ -156,7 +201,7 @@ class StaticProgressBar extends StatelessWidget {
                   value.duration,
                   latestDraggableOffset!,
                 )
-              : null,
+              : pendingSeekPosition,
           colors: colors,
           barHeight: barHeight,
           handleHeight: handleHeight,
@@ -184,8 +229,9 @@ class _ProgressBarPainter extends CustomPainter {
   final double handleHeight;
   final bool drawShadow;
 
-  /// The value of the draggable progress bar.
-  /// If null, the progress bar is not being dragged.
+  /// The position to paint instead of [VideoPlayerValue.position]: either the
+  /// one currently being dragged, or the one of a seek that is still in
+  /// flight. If null, neither is happening and the reported position is used.
   final Duration? draggableValue;
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^6.0.0
+  video_player_platform_interface: ^6.9.0
 
 flutter:
   uses-material-design: true

--- a/test/progress_bar_seek_test.dart
+++ b/test/progress_bar_seek_test.dart
@@ -1,0 +1,287 @@
+import 'dart:async';
+
+import 'package:chewie/src/progress_bar.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:video_player/video_player.dart';
+import 'package:video_player_platform_interface/video_player_platform_interface.dart';
+
+const Duration _videoDuration = Duration(minutes: 1);
+
+/// A platform implementation whose seeks only complete when the test says so,
+/// which is what makes the seek latency of a real platform (notably iOS)
+/// observable.
+class _FakeVideoPlayerPlatform extends VideoPlayerPlatform {
+  // Single-subscription so the initialized event is buffered until
+  // `initialize()` gets around to listening.
+  final StreamController<VideoEvent> _events = StreamController<VideoEvent>();
+
+  final List<Completer<void>> pendingSeeks = <Completer<void>>[];
+  final List<String> calls = <String>[];
+
+  Duration position = Duration.zero;
+
+  void completePendingSeeks() {
+    for (final Completer<void> seek in pendingSeeks) {
+      if (!seek.isCompleted) {
+        seek.complete();
+      }
+    }
+    pendingSeeks.clear();
+  }
+
+  @override
+  Future<void> init() async {}
+
+  @override
+  Future<int?> createWithOptions(VideoCreationOptions options) async {
+    _events.add(
+      VideoEvent(
+        eventType: VideoEventType.initialized,
+        duration: _videoDuration,
+        size: const Size(640, 360),
+      ),
+    );
+    return 1;
+  }
+
+  @override
+  Stream<VideoEvent> videoEventsFor(int playerId) => _events.stream;
+
+  @override
+  Future<void> seekTo(int playerId, Duration position) {
+    calls.add('seekTo');
+    final Completer<void> completer = Completer<void>();
+    pendingSeeks.add(completer);
+    return completer.future.then((_) => this.position = position);
+  }
+
+  @override
+  Future<Duration> getPosition(int playerId) async => position;
+
+  @override
+  Future<void> play(int playerId) async => calls.add('play');
+
+  @override
+  Future<void> pause(int playerId) async => calls.add('pause');
+
+  @override
+  Future<void> setLooping(int playerId, bool looping) async {}
+
+  @override
+  Future<void> setVolume(int playerId, double volume) async {}
+
+  @override
+  Future<void> setPlaybackSpeed(int playerId, double speed) async {}
+
+  @override
+  Future<void> setPreventsDisplaySleepDuringVideoPlayback(
+    int playerId,
+    bool prevent,
+  ) async {}
+
+  @override
+  Future<void> dispose(int playerId) async {}
+
+  @override
+  Widget buildViewWithOptions(VideoViewOptions options) =>
+      const SizedBox.shrink();
+}
+
+/// Returns a controller backed by the fake platform.
+///
+/// It is deliberately not disposed: `dispose()` awaits a subscription
+/// cancellation that never resolves under the fake async of `testWidgets`, and
+/// the controllers do not outlive the test anyway.
+Future<VideoPlayerController> _initializedController() async {
+  final VideoPlayerController controller = VideoPlayerController.networkUrl(
+    Uri.parse('https://example.com/video.mp4'),
+  );
+  await controller.initialize();
+  return controller;
+}
+
+StaticProgressBar _progressBar(WidgetTester tester) =>
+    tester.widget<StaticProgressBar>(find.byType(StaticProgressBar));
+
+/// Drags from [from] to [to] without lifting the finger.
+///
+/// The move that makes the recognizer win the arena does not report an update
+/// on its own, hence the extra step past the touch slop first.
+Future<TestGesture> _dragTo(
+  WidgetTester tester, {
+  required Offset from,
+  required Offset to,
+}) async {
+  final TestGesture gesture = await tester.startGesture(from);
+  await gesture.moveBy(const Offset(kDragSlopDefault, 0));
+  await tester.pump();
+  await gesture.moveTo(to);
+  await tester.pump();
+  return gesture;
+}
+
+void main() {
+  late _FakeVideoPlayerPlatform platform;
+
+  setUp(() {
+    platform = _FakeVideoPlayerPlatform();
+    VideoPlayerPlatform.instance = platform;
+  });
+
+  Future<void> pumpProgressBar(
+    WidgetTester tester,
+    VideoPlayerController controller,
+  ) {
+    return tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: VideoProgressBar(
+            controller,
+            barHeight: 5,
+            handleHeight: 6,
+            drawShadow: false,
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('keeps the dropped position painted until the seek completes', (
+    WidgetTester tester,
+  ) async {
+    final VideoPlayerController controller = await _initializedController();
+
+    await pumpProgressBar(tester, controller);
+
+    // The bar spans the whole test surface (800px), so dropping at 75% of it
+    // targets 45s of the 60s video.
+    final Size surface =
+        tester.view.physicalSize / tester.view.devicePixelRatio;
+    final double dropX = surface.width * 0.75;
+
+    final TestGesture gesture = await _dragTo(
+      tester,
+      from: Offset(surface.width * 0.1, surface.height / 2),
+      to: Offset(dropX, surface.height / 2),
+    );
+
+    expect(_progressBar(tester).latestDraggableOffset, isNotNull);
+
+    await gesture.up();
+    await tester.pump();
+
+    // The platform has not acknowledged the seek yet, so the controller still
+    // reports the old position...
+    expect(platform.pendingSeeks, hasLength(1));
+    expect(controller.value.position, Duration.zero);
+
+    // ...but the bar must keep painting where the handle was dropped instead of
+    // snapping back to it.
+    expect(_progressBar(tester).latestDraggableOffset, isNull);
+    expect(
+      _progressBar(tester).pendingSeekPosition,
+      const Duration(seconds: 45),
+    );
+
+    platform.completePendingSeeks();
+    await tester.pump();
+    await tester.pump();
+
+    expect(controller.value.position, const Duration(seconds: 45));
+    expect(_progressBar(tester).pendingSeekPosition, isNull);
+  });
+
+  testWidgets('resumes playback only once the seek has landed', (
+    WidgetTester tester,
+  ) async {
+    final VideoPlayerController controller = await _initializedController();
+
+    await controller.play();
+    await pumpProgressBar(tester, controller);
+    platform.calls.clear();
+
+    final Size surface =
+        tester.view.physicalSize / tester.view.devicePixelRatio;
+    final TestGesture gesture = await _dragTo(
+      tester,
+      from: Offset(surface.width * 0.1, surface.height / 2),
+      to: Offset(surface.width * 0.75, surface.height / 2),
+    );
+    await gesture.up();
+    await tester.pump();
+
+    // Playing before the seek lands would play back from the old position.
+    expect(platform.calls, <String>['pause', 'seekTo']);
+
+    platform.completePendingSeeks();
+    await tester.pump();
+    await tester.pump();
+
+    expect(platform.calls, <String>['pause', 'seekTo', 'play']);
+
+    // Stop the position polling the controller starts when playing, so no
+    // timer outlives the test.
+    await controller.pause();
+  });
+
+  testWidgets('a tap paints the tapped position while the seek is in flight', (
+    WidgetTester tester,
+  ) async {
+    final VideoPlayerController controller = await _initializedController();
+
+    await pumpProgressBar(tester, controller);
+
+    final Size surface =
+        tester.view.physicalSize / tester.view.devicePixelRatio;
+    await tester.tapAt(Offset(surface.width / 2, surface.height / 2));
+    await tester.pump();
+
+    expect(platform.pendingSeeks, hasLength(1));
+    expect(controller.value.position, Duration.zero);
+    expect(
+      _progressBar(tester).pendingSeekPosition,
+      const Duration(seconds: 30),
+    );
+
+    platform.completePendingSeeks();
+    await tester.pump();
+    await tester.pump();
+
+    expect(_progressBar(tester).pendingSeekPosition, isNull);
+  });
+
+  testWidgets('a stale seek does not clear the position of a newer one', (
+    WidgetTester tester,
+  ) async {
+    final VideoPlayerController controller = await _initializedController();
+
+    await pumpProgressBar(tester, controller);
+
+    final Size surface =
+        tester.view.physicalSize / tester.view.devicePixelRatio;
+    await tester.tapAt(Offset(surface.width * 0.25, surface.height / 2));
+    await tester.pump();
+    final Completer<void> firstSeek = platform.pendingSeeks.first;
+
+    await tester.tapAt(Offset(surface.width * 0.75, surface.height / 2));
+    await tester.pump();
+    expect(platform.pendingSeeks, hasLength(2));
+
+    // The first seek lands late, after a newer one was requested.
+    firstSeek.complete();
+    await tester.pump();
+    await tester.pump();
+
+    expect(
+      _progressBar(tester).pendingSeekPosition,
+      const Duration(seconds: 45),
+    );
+
+    platform.completePendingSeeks();
+    await tester.pump();
+    await tester.pump();
+
+    expect(_progressBar(tester).pendingSeekPosition, isNull);
+  });
+}


### PR DESCRIPTION
## Problem

Dragging the progress bar handle and releasing it makes the handle jump back to the previous playback position for a few frames before landing on the target. The same lag affects a plain tap on the bar, where the handle does not move until the seek finishes.

`VideoPlayerController.seekTo()` only writes the new position into `VideoPlayerValue.position` *after* the platform reports the seek complete:

```dart
await _videoPlayerPlatform.seekTo(_playerId, position);
_updatePosition(position);
```

`_VideoProgressBarState` cleared `_latestDraggableOffset` synchronously right after firing the seek, so for the whole duration of the platform round-trip the painter fell back to the stale `value.position`.

The window is longest on iOS — `FVPVideoPlayer.seekTo` calls `AVPlayer.seekToTime` with `kCMTimeZero` tolerance, so it waits for the exact target frame to be decoded — which is where it was reported, but the flicker exists on every platform.

A second, smaller issue: `controller.play()` was called *before* the seek was issued, so the player briefly resumed at the old position (visible in both the video and the audio) while the seek was still in flight.

## Fix

- Track the requested position in `_pendingSeekPosition` and keep painting it until `seekTo()` resolves. Paint priority is now active drag offset → pending seek position → reported position. Both of the first two derive the same `Duration`, so the handoff on finger-release is pixel-identical and there is no visible transition.
- A `_latestSeekRequestId` counter so a slow seek resolving after a newer one cannot clear the newer position.
- Taps go through the same path, so the handle moves to the tapped point immediately.
- Resume playback only once the seek has landed. `onDragEnd` still fires synchronously first, so hide-timer behaviour in the controls is unchanged.

`StaticProgressBar` gains an optional `pendingSeekPosition` parameter; the existing `latestDraggableOffset` is untouched, so this is not a breaking change.

## Tests

Four widget tests in `test/progress_bar_seek_test.dart`, driven by a fake `VideoPlayerPlatform` whose seeks complete only when the test says so — which is what makes the platform latency observable:

- the dropped position stays painted while the controller still reports the old one
- playback resumes only after the seek lands
- a tap paints the tapped position immediately
- a stale seek does not clear the position requested by a newer one

This adds `video_player_platform_interface` as a dev dependency, needed to implement the fake.

`flutter test` passes, `flutter analyze` is clean, and the code is `dart format`ted.

## Verification

Confirmed fixed on a physical iPhone (iOS 26.5, release build) with the example app, on both the Cupertino and Material controls.
