### PR TITLE
Flutter 3.47 upgrade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,9 @@ env:
   # refer to https://docs.flutter.dev/development/tools/sdk/releases.
   # Note: The version below should be manually updated to the latest second most recent version
   # after a new stable version comes out.
-  # Current minimum is set to Flutter 3.41. Make the next version the new minimum once the next
+  # Current minimum is set to Flutter 3.44. Make the next version the new minimum once the next
   # stable version is released
-  FLUTTER_VERSION_MINIMUM_DEFAULT: "3.41.9"
+  FLUTTER_VERSION_MINIMUM_DEFAULT: "3.44.7"
   FLUTTER_VERSION_LATEST_STABLE_CHANNEL_DEFAULT: "3.x"
 
 jobs:

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -5,6 +5,13 @@ analyzer:
     strict-raw-types: true
   exclude:
     - lib/generated_plugin_registrant.dart
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
   errors:
     # allow self-reference to deprecated members (we do this because otherwise we have
     # to annotate every member in every test, assert, etc, when we deprecate something)

--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -5,6 +5,13 @@ analyzer:
     strict-raw-types: true
   exclude:
     - lib/generated_plugin_registrant.dart
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 
 linter:
   rules:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -4,15 +4,15 @@ version: 1.0.0
 publish_to: none
 
 environment:
-  sdk: '>=3.11.0 <4.0.0'
-  flutter: ">=3.41.0"
+  sdk: '>=3.12.0 <4.0.0'
+  flutter: ">=3.44.0"
 
 dependencies:
   chewie:
     path: ../
   flutter:
     sdk: flutter
-  video_player: ^2.11.1
+  video_player: ^2.14.0
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,16 +4,16 @@ version: 1.15.0
 homepage: https://github.com/fluttercommunity/chewie
 
 environment:
-  sdk: '>=3.10.0 <4.0.0'
-  flutter: ">=3.41.0"
+  sdk: '>=3.11.0 <4.0.0'
+  flutter: ">=3.44.0"
 
 dependencies:
   cupertino_icons: ^1.0.9
   flutter:
     sdk: flutter
   provider: ^6.1.5+1
-  video_player: ^2.11.1
-  wakelock_plus: ^1.7.0
+  video_player: ^2.14.0
+  wakelock_plus: ^1.8.0
   web: ^1.1.1
 
 dev_dependencies:


### PR DESCRIPTION
Upgraded minimum supported Flutter version to 3.44 as a result of 3.47.