### PR TITLE
Reformat _PlaybackSpeedDialog to satisfy dart format

### DIFF
--- a/lib/src/cupertino/cupertino_controls.dart
+++ b/lib/src/cupertino/cupertino_controls.dart
@@ -754,10 +754,7 @@ class _CupertinoControlsState extends State<CupertinoControls>
 }
 
 class _PlaybackSpeedDialog extends StatelessWidget {
-  const _PlaybackSpeedDialog({
-    required this._speeds,
-    required this._selected,
-  });
+  const _PlaybackSpeedDialog({required this._speeds, required this._selected});
 
   final List<double> _speeds;
   final double _selected;


### PR DESCRIPTION
## Problem

`master` is not `dart format`-clean under the formatter shipped with Flutter 3.47, which CI resolves for the `3.x` (latest stable) matrix entry:

```
✨ Check Formatting → dart format --set-exit-if-changed lib
Formatted lib/src/cupertino/cupertino_controls.dart
Formatted 30 files (1 changed) in 0.08 seconds
##[error]Process completed with exit code 1
```

That step is only `continue-on-error` for the minimum version, so it is enforced on `3.x`. The result is that **every open pull request currently fails CI regardless of its contents** — the file is untouched by those PRs.

Presumably fallout from #967: the formatter's behaviour changed in 3.47 and this file was not re-run.

## Fix

`dart format lib` on a clean checkout of `master`. It touches exactly one constructor:

```dart
- const _PlaybackSpeedDialog({
-   required this._speeds,
-   required this._selected,
- });
+ const _PlaybackSpeedDialog({required this._speeds, required this._selected});
```

No behaviour change. After this, `dart format --set-exit-if-changed lib` and `flutter analyze lib` both pass on `master`.

No CHANGELOG entry, since this is not user-visible.