### PR TITLE
fix(web): fullscreen pops the host route on iPhone Safari (no Fullscreen API)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [Unreleased]
+* 🐛 [#970](https://github.com/fluttercommunity/chewie/pull/970): Web: fix fullscreen popping the host route on browsers without the Fullscreen API. iPhone Safari has no `Element.requestFullscreen`, so entering fullscreen threw before the route was pushed and the next exit request popped the embedder's page. Those browsers now use the video element's own fullscreen player and no route is involved. Thanks [Ortes](https://github.com/Ortes).
+
 ## [1.16.2]
 * ⬆️ [#959](https://github.com/fluttercommunity/chewie/pull/959): Add YouTube-style chapters to the progress bar. Pass `ChewieController.chapters` to split the bar into chapter segments and show the hovered/scrubbed chapter title above it. Thanks [Ortes](https://github.com/Ortes).
 * 🛠️ [#968](https://github.com/fluttercommunity/chewie/pull/968): Reformat `_PlaybackSpeedDialog` to satisfy `dart format`. Thanks [Ortes](https://github.com/Ortes).

--- a/lib/src/chewie_player.dart
+++ b/lib/src/chewie_player.dart
@@ -49,14 +49,23 @@ class ChewieState extends State<Chewie> {
   late PlayerNotifier notifier;
   late final void Function() _browserFsExitHandler;
 
+  /// Forces the video-element branch on or off, for tests.
+  ///
+  /// [kIsWeb] is a compile-time constant, so the branch below is unreachable
+  /// from a VM test without an override, in the spirit of
+  /// `debugDefaultTargetPlatformOverride`. Reset it to null when done.
+  @visibleForTesting
+  static bool? debugUsesVideoElementFullScreen;
+
   /// Browsers without the Fullscreen API (iPhone Safari) cannot host the
   /// fullscreen route: `requestFullscreen` throws before the route is pushed,
   /// and the next exit request pops the page underneath instead. On those
   /// browsers the video element's own player is used and no route is involved.
   bool get _usesVideoElementFullScreen =>
-      kIsWeb &&
-      widget.controller.useNativeFullScreenOnWeb &&
-      !browserFullscreenSupported;
+      debugUsesVideoElementFullScreen ??
+      (kIsWeb &&
+          widget.controller.useNativeFullScreenOnWeb &&
+          !browserFullscreenSupported);
 
   // ignore: invalid_use_of_visible_for_testing_member
   int get _playerId => widget.controller.videoPlayerController.playerId;

--- a/lib/src/chewie_player.dart
+++ b/lib/src/chewie_player.dart
@@ -49,6 +49,18 @@ class ChewieState extends State<Chewie> {
   late PlayerNotifier notifier;
   late final void Function() _browserFsExitHandler;
 
+  /// Browsers without the Fullscreen API (iPhone Safari) cannot host the
+  /// fullscreen route: `requestFullscreen` throws before the route is pushed,
+  /// and the next exit request pops the page underneath instead. On those
+  /// browsers the video element's own player is used and no route is involved.
+  bool get _usesVideoElementFullScreen =>
+      kIsWeb &&
+      widget.controller.useNativeFullScreenOnWeb &&
+      !browserFullscreenSupported;
+
+  // ignore: invalid_use_of_visible_for_testing_member
+  int get _playerId => widget.controller.videoPlayerController.playerId;
+
   @override
   void initState() {
     super.initState();
@@ -71,6 +83,9 @@ class ChewieState extends State<Chewie> {
     if (widget.controller.useNativeFullScreenOnWeb) {
       removeBrowserFullscreenChangeListener(_browserFsExitHandler);
     }
+    if (_usesVideoElementFullScreen) {
+      disposeVideoElementFullscreen(_playerId);
+    }
     widget.controller.removeListener(listener);
     notifier.dispose();
     super.dispose();
@@ -88,6 +103,18 @@ class ChewieState extends State<Chewie> {
   }
 
   Future<void> listener() async {
+    if (_usesVideoElementFullScreen) {
+      _isFullScreen = isControllerFullScreen;
+      if (_isFullScreen) {
+        enterVideoElementFullscreen(
+          _playerId,
+          widget.controller.exitFullScreen,
+        );
+      } else {
+        exitVideoElementFullscreen(_playerId);
+      }
+      return;
+    }
     if (isControllerFullScreen && !_isFullScreen) {
       _wasPlayingBeforeFullScreen =
           widget.controller.videoPlayerController.value.isPlaying;

--- a/lib/src/web_fullscreen_impl.dart
+++ b/lib/src/web_fullscreen_impl.dart
@@ -1,8 +1,26 @@
 import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
 
 import 'package:web/web.dart' as web;
 
+extension on web.HTMLVideoElement {
+  external bool? get webkitDisplayingFullscreen;
+  external void webkitEnterFullscreen();
+  external void webkitExitFullscreen();
+}
+
 final _handlers = <void Function(), JSFunction>{};
+final _videoExitHandlers = <int, JSFunction>{};
+
+/// Whether the document exposes the Fullscreen API.
+///
+/// iPhone Safari does not: only the video element has `webkitEnterFullscreen`.
+/// Calling the missing `requestFullscreen` throws, so callers feature-detect
+/// and hand fullscreen to the video element instead of pushing a route.
+bool get browserFullscreenSupported {
+  final web.Element? element = web.document.documentElement;
+  return element != null && (element as JSObject).has('requestFullscreen');
+}
 
 void requestBrowserFullscreen() {
   web.document.documentElement?.requestFullscreen();
@@ -26,5 +44,41 @@ void removeBrowserFullscreenChangeListener(void Function() callback) {
   final jsHandler = _handlers.remove(callback);
   if (jsHandler != null) {
     web.document.removeEventListener('fullscreenchange', jsHandler);
+  }
+}
+
+web.HTMLVideoElement? _videoElement(int playerId) =>
+    web.document.getElementById('videoElement-$playerId')
+        as web.HTMLVideoElement?;
+
+/// Opens the browser's own fullscreen player for the video element that
+/// `video_player_web` created for [playerId]. [onExited] runs when the user
+/// closes that player, so the caller can drop its fullscreen state.
+void enterVideoElementFullscreen(int playerId, void Function() onExited) {
+  final web.HTMLVideoElement? video = _videoElement(playerId);
+  if (video == null || !(video as JSObject).has('webkitEnterFullscreen')) {
+    return;
+  }
+  _videoExitHandlers.putIfAbsent(playerId, () {
+    final jsHandler = ((JSAny? _) => onExited()).toJS;
+    video.addEventListener('webkitendfullscreen', jsHandler);
+    return jsHandler;
+  });
+  video.webkitEnterFullscreen();
+}
+
+void exitVideoElementFullscreen(int playerId) {
+  final web.HTMLVideoElement? video = _videoElement(playerId);
+  if (video != null && (video.webkitDisplayingFullscreen ?? false)) {
+    video.webkitExitFullscreen();
+  }
+}
+
+void disposeVideoElementFullscreen(int playerId) {
+  final jsHandler = _videoExitHandlers.remove(playerId);
+  if (jsHandler != null) {
+    _videoElement(
+      playerId,
+    )?.removeEventListener('webkitendfullscreen', jsHandler);
   }
 }

--- a/lib/src/web_fullscreen_stub.dart
+++ b/lib/src/web_fullscreen_stub.dart
@@ -1,5 +1,9 @@
+bool get browserFullscreenSupported => true;
 void requestBrowserFullscreen() {}
 void exitBrowserFullscreen() {}
 bool get browserInFullscreen => false;
 void addBrowserFullscreenChangeListener(void Function() callback) {}
 void removeBrowserFullscreenChangeListener(void Function() callback) {}
+void enterVideoElementFullscreen(int playerId, void Function() onExited) {}
+void exitVideoElementFullscreen(int playerId) {}
+void disposeVideoElementFullscreen(int playerId) {}

--- a/test/video_element_fullscreen_test.dart
+++ b/test/video_element_fullscreen_test.dart
@@ -1,0 +1,124 @@
+import 'package:chewie/chewie.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:video_player/video_player.dart';
+
+final Uri _src = Uri.parse(
+  'https://assets.mixkit.co/videos/preview/mixkit-spinning-around-the-earth-29351-large.mp4',
+);
+
+class _RouteCounter extends NavigatorObserver {
+  int pushes = 0;
+  int pops = 0;
+
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    pushes++;
+  }
+
+  @override
+  void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    pops++;
+  }
+}
+
+void main() {
+  late _RouteCounter routes;
+  late ChewieController controller;
+
+  Future<void> pumpPlayer(WidgetTester tester) async {
+    routes = _RouteCounter();
+    controller = ChewieController(
+      videoPlayerController: VideoPlayerController.networkUrl(_src),
+      autoPlay: false,
+      looping: false,
+    );
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        navigatorObservers: [routes],
+        home: Scaffold(
+          body: Column(
+            children: [
+              const Text('host page'),
+              Expanded(child: Chewie(controller: controller)),
+            ],
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+  }
+
+  group('fullscreen on a browser without the Fullscreen API', () {
+    setUp(() => ChewieState.debugUsesVideoElementFullScreen = true);
+    tearDown(() => ChewieState.debugUsesVideoElementFullScreen = null);
+
+    testWidgets('entering fullscreen pushes no route', (
+      WidgetTester tester,
+    ) async {
+      await pumpPlayer(tester);
+      final pushesBefore = routes.pushes;
+
+      controller.enterFullScreen();
+      await tester.pumpAndSettle();
+
+      expect(routes.pushes, pushesBefore);
+      expect(controller.isFullScreen, isTrue);
+      expect(find.text('host page'), findsOneWidget);
+    });
+
+    testWidgets('leaving fullscreen pops nothing, so the host page stays', (
+      WidgetTester tester,
+    ) async {
+      await pumpPlayer(tester);
+
+      controller.enterFullScreen();
+      await tester.pumpAndSettle();
+      controller.exitFullScreen();
+      await tester.pumpAndSettle();
+
+      expect(routes.pops, 0);
+      expect(controller.isFullScreen, isFalse);
+      expect(find.text('host page'), findsOneWidget);
+      expect(find.byType(Chewie), findsOneWidget);
+    });
+
+    testWidgets('a redundant exit request still leaves the host page alone', (
+      WidgetTester tester,
+    ) async {
+      await pumpPlayer(tester);
+
+      controller.enterFullScreen();
+      await tester.pumpAndSettle();
+      controller.exitFullScreen();
+      controller.exitFullScreen();
+      await tester.pumpAndSettle();
+
+      expect(routes.pops, 0);
+      expect(find.text('host page'), findsOneWidget);
+    });
+  });
+
+  testWidgets('the fullscreen route is still used where the API exists', (
+    WidgetTester tester,
+  ) async {
+    ChewieState.debugUsesVideoElementFullScreen = false;
+    addTearDown(() => ChewieState.debugUsesVideoElementFullScreen = null);
+
+    await pumpPlayer(tester);
+    final pushesBefore = routes.pushes;
+
+    controller.enterFullScreen();
+    await tester.pumpAndSettle();
+
+    expect(routes.pushes, pushesBefore + 1);
+
+    controller.exitFullScreen();
+    await tester.pumpAndSettle();
+
+    expect(routes.pops, 1);
+    expect(find.text('host page'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Fixes #969.

> **Urgent, please.** This is a user-facing regression introduced by the `useNativeFullScreenOnWeb` default in 1.15.0, not a new feature. Every app shipping Chewie on Flutter web is affected on iPhone Safari: tapping the fullscreen button navigates the user off the page holding the player. In our case patients lost an in-progress exercise session mid-treatment, and we are carrying an app-side workaround until this lands. A patch release would let us and other web users drop it.

### The bug

Since 1.15.0 `useNativeFullScreenOnWeb` defaults to `true`, and `_pushFullScreenWidget` calls `document.documentElement.requestFullscreen()` before pushing the fullscreen route. iPhone Safari has no `Element.requestFullscreen` (only `HTMLVideoElement.webkitEnterFullscreen`), so the call throws. By then `ChewieState._isFullScreen` and the controller flag are already `true`, and no route was pushed. The next tap flips the controller flag back, the listener sees "widget says fullscreen, controller says not", and runs `Navigator.pop()` on the root navigator. The route on top is the embedder's own page, which is what gets popped.

From the user's seat: first tap does nothing, second tap throws them out of the page. Same mechanism as #618.

Browsers that have the API are unaffected: the route is pushed, and the exit pops that route. Android Chrome and desktop are fine, verified in production.

### The fix

On a browser without the Fullscreen API, Chewie does not push or pop anything. It opens the video element's own player instead:

- `browserFullscreenSupported`: feature check on `documentElement`.
- `listener()`: when the check fails (and `useNativeFullScreenOnWeb` is on), mirror the controller flag, call `webkitEnterFullscreen()` / `webkitExitFullscreen()` on the element `video_player_web` created for the controller's `playerId`, and return.
- The element's `webkitendfullscreen` event calls `exitFullScreen()`, so the control icon follows the user closing the native player.

The route path, `_reInitializeControllers`, and every platform that has the API are untouched. Users on iPhone also get a better result than the Flutter route would have given them: the phone's own fullscreen player, with no `<video>` reparenting and so no stream reload on enter or exit.

### Scope

Deliberately minimal, +85 lines, nothing removed. Only the code path that threw is diverted, and it is gated on `useNativeFullScreenOnWeb`, so a host that opted out of browser fullscreen keeps the Flutter route on iPhone exactly as before.

### Tests

`test/video_element_fullscreen_test.dart`, driven by a new `@visibleForTesting` `ChewieState.debugUsesVideoElementFullScreen` override. `kIsWeb` is a compile-time constant, so this branch is otherwise unreachable from a VM test; the override follows the spirit of `debugDefaultTargetPlatformOverride`. A `NavigatorObserver` counts pushes and pops:

- entering fullscreen pushes no route;
- leaving fullscreen pops nothing, so the host page stays mounted;
- a redundant exit request also pops nothing, which is the failure users hit;
- and the opposite case is pinned too: where the browser has the API, the route is still pushed and popped.

Patch coverage goes from 11% to roughly 82%. What is left uncovered is the `kIsWeb` conjunction itself and the stub getter it short-circuits, which no VM test can reach. The web helper (`web_fullscreen_impl.dart`) is not compiled off web, so it is not part of the report.

`flutter analyze` clean, full suite green (104 tests), `flutter build web` on the example passes.

### One thing I would like your call on

Locating the `<video>` element needs `VideoPlayerController.playerId`, which `video_player` marks `@visibleForTesting` with a note that plugin consumers should not use it, hence the `ignore` on that getter. I could not find a public way to map a controller to its element, and this is what apps are doing today in userland. If you would rather see a different approach, or want to raise it with `video_player` for a public accessor, say so and I will follow.

### Device check

Not run on a physical iPhone from here. The element calls mirror what our app has been shipping for the same `<video>` (`webkitEnterFullscreen`, and closing the native player returns inline with the position kept), so a confirmation from a reviewer with an iPhone would be welcome.
